### PR TITLE
Change var to let in model generation

### DIFF
--- a/Templates/modelObject.mustache
+++ b/Templates/modelObject.mustache
@@ -9,11 +9,11 @@ public struct {{classname}}: Codable {
 {{#allVars}}
 {{#isEnum}}
     {{#description}}/// {{description}}
-    {{/description}}public var {{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}
+    {{/description}}public let {{name}}: {{{datatypeWithEnum}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}
 {{/isEnum}}
 {{^isEnum}}
     {{#description}}/// {{description}}
-    {{/description}}public var {{name}}: {{{datatype}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{#objcCompatible}}{{#vendorExtensions.x-swift-optional-scalar}}
+    {{/description}}public let {{name}}: {{{datatype}}}{{^required}}?{{/required}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{#objcCompatible}}{{#vendorExtensions.x-swift-optional-scalar}}
     public var {{name}}Num: NSNumber? {
         get {
             return {{name}}.map({ return NSNumber(value: $0) })

--- a/Tests/__Snapshots__/APIClientDocumentationTests/testModelDocumented.1.swift
+++ b/Tests/__Snapshots__/APIClientDocumentationTests/testModelDocumented.1.swift
@@ -17,12 +17,12 @@ public struct PetDocumented: Codable {
         case sold = "sold"
     }
 
-    public var _id: Int64?
-    public var name: String
+    public let _id: Int64?
+    public let name: String
     /// pet docs for photoUrls
-    public var photoUrls: [String]
+    public let photoUrls: [String]
     /// pet status in the store
-    public var status: Status?
+    public let status: Status?
 
     public init(_id: Int64?, name: String, photoUrls: [String], status: Status?) {
         self._id = _id

--- a/Tests/__Snapshots__/APIClientModelsTests/testModelDefinitionOptional_BuildModelWithOptionals.1.swift
+++ b/Tests/__Snapshots__/APIClientModelsTests/testModelDefinitionOptional_BuildModelWithOptionals.1.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct Pet: Codable {
 
-    public var name: String?
+    public let name: String?
 
     public init(name: String?) {
         self.name = name

--- a/Tests/__Snapshots__/APIClientModelsTests/testModelDefinition_BuildPetModel.1.swift
+++ b/Tests/__Snapshots__/APIClientModelsTests/testModelDefinition_BuildPetModel.1.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct Pet: Codable {
 
-    public var name: String
+    public let name: String
 
     public init(name: String) {
         self.name = name

--- a/Tests/__Snapshots__/APIClientModelsTests/testModelInResponse_Model.1.swift
+++ b/Tests/__Snapshots__/APIClientModelsTests/testModelInResponse_Model.1.swift
@@ -16,10 +16,10 @@ public struct Pet: Codable {
         case sold = "sold"
     }
 
-    public var _id: Int64?
-    public var name: String?
-    public var photoUrls: [String]?
-    public var status: Status?
+    public let _id: Int64?
+    public let name: String?
+    public let photoUrls: [String]?
+    public let status: Status?
 
     public init(_id: Int64?, name: String?, photoUrls: [String]?, status: Status?) {
         self._id = _id

--- a/Tests/__Snapshots__/APIClientModelsTests/testModelWithReferences.1.swift
+++ b/Tests/__Snapshots__/APIClientModelsTests/testModelWithReferences.1.swift
@@ -16,12 +16,12 @@ public struct Pet: Codable {
         case sold = "sold"
     }
 
-    public var _id: Int64?
-    public var category: Category?
-    public var name: String
-    public var photoUrls: [String]
-    public var tags: [Tag]?
-    public var status: Status?
+    public let _id: Int64?
+    public let category: Category?
+    public let name: String
+    public let photoUrls: [String]
+    public let tags: [Tag]?
+    public let status: Status?
 
     public init(_id: Int64?, category: Category?, name: String, photoUrls: [String], tags: [Tag]?, status: Status?) {
         self._id = _id

--- a/Tests/__Snapshots__/APIClientModelsTests/testRequestWithPetReference_BuildPetModel.1.swift
+++ b/Tests/__Snapshots__/APIClientModelsTests/testRequestWithPetReference_BuildPetModel.1.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct Pet: Codable {
 
-    public var name: String
+    public let name: String
 
     public init(name: String) {
         self.name = name


### PR DESCRIPTION
This PR changes generation of fields in structs from `var` to `let` to enforce immutability of the created models.