### PR TITLE
Quick start and Legal docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ sudo: required
 
 addons:
   homebrew:
-    casks: homebrew/cask-versions/adoptopenjdk8
+    taps:
+      - adoptopenjdk/openjdk
+    casks:
+      - adoptopenjdk/openjdk/adoptopenjdk8
 
 env:
   global:

--- a/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Adding the module to your project.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Adding the module to your project.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Adding the module to your project
+ */
+// nef:end
+/*:
+ # Adding the module to your project
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Customizing the configuration.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Customizing the configuration.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Customizing the configuration
+ */
+// nef:end
+/*:
+ # Customizing the configuration
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Running a network request.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Running a network request.xcplaygroundpage/Contents.swift
@@ -1,3 +1,10 @@
-import UIKit
-
-var str = "Hello, playground"
+// nef:begin:header
+/*
+ layout: docs
+ title: Running a network request
+ */
+// nef:end
+/*:
+ # Running a network request
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Running a network request.xcplaygroundpage/timeline.xctimeline
+++ b/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Running a network request.xcplaygroundpage/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Testing your network calls.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Consuming generated code.playground/Pages/Testing your network calls.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Testing your network calls
+ */
+// nef:end
+/*:
+ # Testing your network calls
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Basic generation.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Basic generation.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Basic generation
+ */
+// nef:end
+/*:
+ # Basic generation
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Data types.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Data types.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Data types
+ */
+// nef:end
+/*:
+ # Data types
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Documentation.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Documentation.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Documentation
+ */
+// nef:end
+/*:
+ # Documentation
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Grouping endpoints.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Grouping endpoints.xcplaygroundpage/Contents.swift
@@ -1,3 +1,10 @@
-import UIKit
-
-var str = "Hello, playground"
+// nef:begin:header
+/*
+ layout: docs
+ title: Grouping endpoints
+ */
+// nef:end
+/*:
+ # Grouping endpoints
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Grouping endpoints.xcplaygroundpage/timeline.xctimeline
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Grouping endpoints.xcplaygroundpage/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Headers.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Headers.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Headers
+ */
+// nef:end
+/*:
+ # Headers
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Limitations.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Limitations.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Limitations
+ */
+// nef:end
+/*:
+ # Limitations
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Parameters.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Generation examples.playground/Pages/Parameters.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Parameters
+ */
+// nef:end
+/*:
+ # Parameters
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Legal.playground/Pages/Credits.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Legal.playground/Pages/Credits.xcplaygroundpage/Contents.swift
@@ -1,7 +1,20 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Credits
+ */
+// nef:end
+/*:
+ # Credits
+ 
+ 2019 - © The Bow Authors
+ 
+ For a comprehensive list of contributors, [visit the repository](https://github.com/bow-swift/bow-openapi/graphs/contributors) on GitHub.
+ 
+ Bow Open API is supported by [47 Degrees](https://www.47deg.com).
+ 
+ This library uses the following libraries or tools:
+ 
+ - [Bow](https://github.com/bow-swift/bow)
+ - [swagger-codegen](https://github.com/swagger-api/swagger-codegen)
+ */

--- a/Documentation.app/Contents/MacOS/Legal.playground/Pages/Credits.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Legal.playground/Pages/Credits.xcplaygroundpage/Contents.swift
@@ -7,11 +7,11 @@
 /*:
  # Credits
  
- 2019 - © The Bow Authors
+ 2019 - © The Bow OpenAPI Authors
  
  For a comprehensive list of contributors, [visit the repository](https://github.com/bow-swift/bow-openapi/graphs/contributors) on GitHub.
  
- Bow Open API is supported by [47 Degrees](https://www.47deg.com).
+ Bow OpenAPI is supported by [47 Degrees](https://www.47deg.com).
  
  This library uses the following libraries or tools:
  

--- a/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/Contents.swift
@@ -7,7 +7,7 @@
 /*:
  # License
  
- Copyright 2018 The Bow OpenAPI Authors
+ Copyright 2019 The Bow OpenAPI Authors
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/Contents.swift
@@ -1,3 +1,200 @@
-import UIKit
-
-var str = "Hello, playground"
+// nef:begin:header
+/*
+ layout: docs
+ title: License
+ */
+// nef:end
+/*:
+ # License
+ 
+ Copyright 2018 The Bow Open API Authors
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ 
+ ------------------------------------------------------------------------
+ 
+ Apache License
+ Version 2.0, January 2004
+ http://www.apache.org/licenses/
+ 
+ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ 
+ 1. Definitions.
+ 
+ "License" shall mean the terms and conditions for use, reproduction,
+ and distribution as defined by Sections 1 through 9 of this document.
+ 
+ "Licensor" shall mean the copyright owner or entity authorized by
+ the copyright owner that is granting the License.
+ 
+ "Legal Entity" shall mean the union of the acting entity and all
+ other entities that control, are controlled by, or are under common
+ control with that entity. For the purposes of this definition,
+ "control" means (i) the power, direct or indirect, to cause the
+ direction or management of such entity, whether by contract or
+ otherwise, or (ii) ownership of fifty percent (50%) or more of the
+ outstanding shares, or (iii) beneficial ownership of such entity.
+ 
+ "You" (or "Your") shall mean an individual or Legal Entity
+ exercising permissions granted by this License.
+ 
+ "Source" form shall mean the preferred form for making modifications,
+ including but not limited to software source code, documentation
+ source, and configuration files.
+ 
+ "Object" form shall mean any form resulting from mechanical
+ transformation or translation of a Source form, including but
+ not limited to compiled object code, generated documentation,
+ and conversions to other media types.
+ 
+ "Work" shall mean the work of authorship, whether in Source or
+ Object form, made available under the License, as indicated by a
+ copyright notice that is included in or attached to the work
+ (an example is provided in the Appendix below).
+ 
+ "Derivative Works" shall mean any work, whether in Source or Object
+ form, that is based on (or derived from) the Work and for which the
+ editorial revisions, annotations, elaborations, or other modifications
+ represent, as a whole, an original work of authorship. For the purposes
+ of this License, Derivative Works shall not include works that remain
+ separable from, or merely link (or bind by name) to the interfaces of,
+ the Work and Derivative Works thereof.
+ 
+ "Contribution" shall mean any work of authorship, including
+ the original version of the Work and any modifications or additions
+ to that Work or Derivative Works thereof, that is intentionally
+ submitted to Licensor for inclusion in the Work by the copyright owner
+ or by an individual or Legal Entity authorized to submit on behalf of
+ the copyright owner. For the purposes of this definition, "submitted"
+ means any form of electronic, verbal, or written communication sent
+ to the Licensor or its representatives, including but not limited to
+ communication on electronic mailing lists, source code control systems,
+ and issue tracking systems that are managed by, or on behalf of, the
+ Licensor for the purpose of discussing and improving the Work, but
+ excluding communication that is conspicuously marked or otherwise
+ designated in writing by the copyright owner as "Not a Contribution."
+ 
+ "Contributor" shall mean Licensor and any individual or Legal Entity
+ on behalf of whom a Contribution has been received by Licensor and
+ subsequently incorporated within the Work.
+ 
+ 2. Grant of Copyright License. Subject to the terms and conditions of
+ this License, each Contributor hereby grants to You a perpetual,
+ worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ copyright license to reproduce, prepare Derivative Works of,
+ publicly display, publicly perform, sublicense, and distribute the
+ Work and such Derivative Works in Source or Object form.
+ 
+ 3. Grant of Patent License. Subject to the terms and conditions of
+ this License, each Contributor hereby grants to You a perpetual,
+ worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+ (except as stated in this section) patent license to make, have made,
+ use, offer to sell, sell, import, and otherwise transfer the Work,
+ where such license applies only to those patent claims licensable
+ by such Contributor that are necessarily infringed by their
+ Contribution(s) alone or by combination of their Contribution(s)
+ with the Work to which such Contribution(s) was submitted. If You
+ institute patent litigation against any entity (including a
+ cross-claim or counterclaim in a lawsuit) alleging that the Work
+ or a Contribution incorporated within the Work constitutes direct
+ or contributory patent infringement, then any patent licenses
+ granted to You under this License for that Work shall terminate
+ as of the date such litigation is filed.
+ 
+ 4. Redistribution. You may reproduce and distribute copies of the
+ Work or Derivative Works thereof in any medium, with or without
+ modifications, and in Source or Object form, provided that You
+ meet the following conditions:
+ 
+ (a) You must give any other recipients of the Work or
+ Derivative Works a copy of this License; and
+ 
+ (b) You must cause any modified files to carry prominent notices
+ stating that You changed the files; and
+ 
+ (c) You must retain, in the Source form of any Derivative Works
+ that You distribute, all copyright, patent, trademark, and
+ attribution notices from the Source form of the Work,
+ excluding those notices that do not pertain to any part of
+ the Derivative Works; and
+ 
+ (d) If the Work includes a "NOTICE" text file as part of its
+ distribution, then any Derivative Works that You distribute must
+ include a readable copy of the attribution notices contained
+ within such NOTICE file, excluding those notices that do not
+ pertain to any part of the Derivative Works, in at least one
+ of the following places: within a NOTICE text file distributed
+ as part of the Derivative Works; within the Source form or
+ documentation, if provided along with the Derivative Works; or,
+ within a display generated by the Derivative Works, if and
+ wherever such third-party notices normally appear. The contents
+ of the NOTICE file are for informational purposes only and
+ do not modify the License. You may add Your own attribution
+ notices within Derivative Works that You distribute, alongside
+ or as an addendum to the NOTICE text from the Work, provided
+ that such additional attribution notices cannot be construed
+ as modifying the License.
+ 
+ You may add Your own copyright statement to Your modifications and
+ may provide additional or different license terms and conditions
+ for use, reproduction, or distribution of Your modifications, or
+ for any such Derivative Works as a whole, provided Your use,
+ reproduction, and distribution of the Work otherwise complies with
+ the conditions stated in this License.
+ 
+ 5. Submission of Contributions. Unless You explicitly state otherwise,
+ any Contribution intentionally submitted for inclusion in the Work
+ by You to the Licensor shall be under the terms and conditions of
+ this License, without any additional terms or conditions.
+ Notwithstanding the above, nothing herein shall supersede or modify
+ the terms of any separate license agreement you may have executed
+ with Licensor regarding such Contributions.
+ 
+ 6. Trademarks. This License does not grant permission to use the trade
+ names, trademarks, service marks, or product names of the Licensor,
+ except as required for reasonable and customary use in describing the
+ origin of the Work and reproducing the content of the NOTICE file.
+ 
+ 7. Disclaimer of Warranty. Unless required by applicable law or
+ agreed to in writing, Licensor provides the Work (and each
+ Contributor provides its Contributions) on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied, including, without limitation, any warranties or conditions
+ of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+ PARTICULAR PURPOSE. You are solely responsible for determining the
+ appropriateness of using or redistributing the Work and assume any
+ risks associated with Your exercise of permissions under this License.
+ 
+ 8. Limitation of Liability. In no event and under no legal theory,
+ whether in tort (including negligence), contract, or otherwise,
+ unless required by applicable law (such as deliberate and grossly
+ negligent acts) or agreed to in writing, shall any Contributor be
+ liable to You for damages, including any direct, indirect, special,
+ incidental, or consequential damages of any character arising as a
+ result of this License or out of the use or inability to use the
+ Work (including but not limited to damages for loss of goodwill,
+ work stoppage, computer failure or malfunction, or any and all
+ other commercial damages or losses), even if such Contributor
+ has been advised of the possibility of such damages.
+ 
+ 9. Accepting Warranty or Additional Liability. While redistributing
+ the Work or Derivative Works thereof, You may choose to offer,
+ and charge a fee for, acceptance of support, warranty, indemnity,
+ or other liability obligations and/or rights consistent with this
+ License. However, in accepting such obligations, You may act only
+ on Your own behalf and on Your sole responsibility, not on behalf
+ of any other Contributor, and only if You agree to indemnify,
+ defend, and hold each Contributor harmless for any liability
+ incurred by, or claims asserted against, such Contributor by reason
+ of your accepting any such warranty or additional liability.
+ */

--- a/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/Contents.swift
@@ -7,7 +7,7 @@
 /*:
  # License
  
- Copyright 2018 The Bow Open API Authors
+ Copyright 2018 The Bow OpenAPI Authors
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/timeline.xctimeline
+++ b/Documentation.app/Contents/MacOS/Legal.playground/Pages/License.xcplaygroundpage/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/Documentation.app/Contents/MacOS/Quick start.playground/Pages/How to run Bow OpenAPI.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Quick start.playground/Pages/How to run Bow OpenAPI.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: How to run Bow OpenAPI
+ */
+// nef:end
+/*:
+ # How to run Bow OpenAPI
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Quick start.playground/Pages/How to run Bow OpenAPI.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Quick start.playground/Pages/How to run Bow OpenAPI.xcplaygroundpage/Contents.swift
@@ -7,4 +7,15 @@
 /*:
  # How to run Bow OpenAPI
  
+ Bow OpenAPI runs from your terminal with the following command:
+ 
+ ```bash
+ $> bow-openapi --name NetworkClient --schema API.json --output OutputFolder
+ ```
+ 
+ Where:
+ 
+ - `--name`: Name of the resulting Swift package to be consumed from Swift Package Manager.
+ - `--schema`: Path to a JSON or YAML file containing the OpenAPI / Swagger description of your endpoints.
+ - `--output`: Path to the folder where the tool will write the generated files.
  */

--- a/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Installation guide.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Installation guide.xcplaygroundpage/Contents.swift
@@ -1,5 +1,10 @@
-// nef:begin:hidden
-import UIKit
-
-Nef.Playground.needsIndefiniteExecution(true)
+// nef:begin:header
+/*
+ layout: docs
+ title: Installation guide
+ */
 // nef:end
+/*:
+ # Installation guide
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Installation guide.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Installation guide.xcplaygroundpage/Contents.swift
@@ -7,4 +7,14 @@
 /*:
  # Installation guide
  
+ Bow OpenAPI is available via [Homebrew](https://brew.sh/). If you still don't have it installed in your Mac, you can follow the steps in [this link](https://brew.sh/) to set it up.
+ 
+ Once you have it, you need to run the following commands:
+ 
+ ```bash
+ brew tap bow-swift/bow
+ brew install bow-openapi
+ ```
+ 
+ Bow OpenAPI depends on the tool `swagger-codegen`; if you do not have it installed, Homebrew will install this package prior to installing Bow OpenAPI.
  */

--- a/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Integration in Xcode.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Integration in Xcode.xcplaygroundpage/Contents.swift
@@ -1,7 +1,10 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+// nef:begin:header
+/*
+ layout: docs
+ title: Integration in Xcode
+ */
+// nef:end
+/*:
+ # Integration in Xcode
+ 
+ */

--- a/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Resources.xcplaygroundpage/Contents.swift
+++ b/Documentation.app/Contents/MacOS/Quick start.playground/Pages/Resources.xcplaygroundpage/Contents.swift
@@ -1,7 +1,27 @@
-//: [Previous](@previous)
-
-import Foundation
-
-var str = "Hello, playground"
-
-//: [Next](@next)
+  // nef:begin:header
+/*
+ layout: docs
+ title: Resources
+ */
+// nef:end
+/*:
+ # Resources
+   
+ In this section you can find a list of projects, libraries, presentations or blog posts that use Bow:
+   
+ ## GitHub projects
+ 
+ Be the first one showing here!
+   
+ ## Libraries
+   
+ Be the first one showing here!
+   
+ ## Presentations
+ 
+ Be the first one showing here!
+ 
+ ## Blog posts
+ 
+ Be the first one showing here!
+ */

--- a/Documentation.app/Contents/MacOS/Quick start.playground/contents.xcplayground
+++ b/Documentation.app/Contents/MacOS/Quick start.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='rendered'>
+<playground version='6.0' target-platform='ios' display-mode='raw'>
     <pages>
         <page name='Installation guide'/>
         <page name='How to run Bow OpenAPI'/>

--- a/Documentation.app/Jekyll/Home.md
+++ b/Documentation.app/Jekyll/Home.md
@@ -4,13 +4,13 @@ title: Home
 permalink: /docs/
 ---
 
-# Bow Open API
+# Bow OpenAPI
 
-Bow Open API is a command line tool to generate a network client written in Swift from an Open API specification that uses the environmental effect type `EnvIO` from [Bow](https://bow-swift.io/). Its main features are:
+Bow OpenAPI is a command line tool to generate a network client written in Swift from an OpenAPI specification that uses the environmental effect type `EnvIO` from [Bow](https://bow-swift.io/). Its main features are:
 
-## Parsing of Open API specifications
+## Parsing of OpenAPI specifications
 
-Bow Open API is able to consume Open API / Swagger specifications as either JSON or YAML files. It relies on the `swagger-codegen` command line tool to parse these files, and then provides a set of templates to customize the output of the tool, together with an additional processing of the result.
+Bow OpenAPI is able to consume OpenAPI / Swagger specifications as either JSON or YAML files. It relies on the `swagger-codegen` command line tool to parse these files, and then provides a set of templates to customize the output of the tool, together with an additional processing of the result.
 
 ## Pure functional Swift code
 

--- a/Documentation.app/Jekyll/Home.md
+++ b/Documentation.app/Jekyll/Home.md
@@ -5,3 +5,21 @@ permalink: /docs/
 ---
 
 # Bow Open API
+
+Bow Open API is a command line tool to generate a network client written in Swift from an Open API specification that uses the environmental effect type `EnvIO` from [Bow](https://bow-swift.io/). Its main features are:
+
+## Parsing of Open API specifications
+
+Bow Open API is able to consume Open API / Swagger specifications as either JSON or YAML files. It relies on the `swagger-codegen` command line tool to parse these files, and then provides a set of templates to customize the output of the tool, together with an additional processing of the result.
+
+## Pure functional Swift code
+
+The generated code is written in Swift using the Bow Effects module, resulting in a 100% functional API. It uses `URLSession` under the hood to perform the network requests.
+
+## Compatible with Swift Package Manager
+
+The output of the tool is a Swift package that can be consumed using the Swift Package Manager. You can drag and drop it onto your Xcode project, or provide it to third parties just with your repository link.
+
+## Testability
+
+Besides the main module, the package includes a module for testing that enable seamless testing of your API calls, with stubbing of responses and errors, and easy assertions of the outputs. 


### PR DESCRIPTION
This PR includes content for the pages in Quick start and Legal sections of the documentation, except for the page *Integration in Xcode*, which is left for a future PR. It also includes a minor modification for the rest of pages where the header template has been added.