### PR TITLE
Change absolute path for relative path

### DIFF
--- a/Documentation.app/Contents/MacOS/Documentation.xcworkspace/contents.xcworkspacedata
+++ b/Documentation.app/Contents/MacOS/Documentation.xcworkspace/contents.xcworkspacedata
@@ -5,7 +5,7 @@
       location = "group:../../Jekyll/Home.md">
    </FileRef>
    <FileRef
-      location = "group:/Users/tomasruizlopez/Development/bow-openapi/Documentation.app/Contents/MacOS/Quick start.playground">
+      location = "group:Quick start.playground">
    </FileRef>
    <FileRef
       location = "group:Generation examples.playground">


### PR DESCRIPTION
The documentation contained an absolute path which made it fail during deployment. This PR changes it to a relative path to prevent this issue.