### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: swift
+os: osx
+language: objective-c
 osx_image: xcode11
-sudo: required
 
 addons:
   homebrew:
@@ -53,10 +53,10 @@ jobs:
         - BUNDLE_GEMFILE=./docs/Gemfile bundle exec jekyll build -s docs -d gen-docs
       deploy:
         provider: pages
-        skip-cleanup: true
-        github-token: $GITHUB_TOKEN
-        keep-history: true
-        local-dir: gen-docs
-        target-branch: gh-pages
+        cleanup: true
+        token: $GITHUB_TOKEN
+        keep_history: true
+        local_dir: gen-docs
+        target_branch: gh-pages
         on:
           all_branches: true


### PR DESCRIPTION
Travis CI is giving some warnings regarding the current config:

- ⚠ `root`: deprecated key `sudo` (The key `sudo` has no effect anymore.)
- ⚠ `jobs.include.deploy`: deprecated key skip_cleanup (not supported in dpl v2, use `cleanup`)
- ℹ️ `jobs.include.deploy`: key `local-dir` is not underscored, using `local_dir`
- ℹ️ `jobs.include.deploy`: key `keep-history` is not underscored, using `keep_history`
- ℹ️ `root`: missing `os`, using the default `osx`
- ℹ️ `jobs.include.deploy`: key `skip-cleanup` is not underscored, using `skip_cleanup`
- ℹ️ `language`: value `swift` is an alias for `objective-c`, using `objective-c`
- ℹ️ `jobs.include.deploy`: key `github-token` is an alias for `token`, using `token`
- ℹ️ `jobs.include.deploy`: key `target-branch` is not underscored, using `target_branch`

This PR makes suggested changes on the Travis config.