### PR TITLE
Create sctructure into module name

### DIFF
--- a/BowOpenAPI.xcodeproj/project.pbxproj
+++ b/BowOpenAPI.xcodeproj/project.pbxproj
@@ -192,11 +192,11 @@
 		8B8B19B523426AE4009D195A /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B8B19B723426AE4009D195A /* APIConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfigTests.swift; sourceTree = "<group>"; };
 		8B8B19B923426AE4009D195A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8B8B19CC23426B83009D195A /* petstore.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = petstore.yaml; sourceTree = "<group>"; };
 		8B8B1C1623436195009D195A /* API+Generators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "API+Generators.swift"; sourceTree = "<group>"; };
 		8BA3B6D1235613AD005D6278 /* GeneratorAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorAPIClientTests.swift; sourceTree = "<group>"; };
 		8BA3B6D4235620B8005D6278 /* ClientGeneratorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientGeneratorMock.swift; sourceTree = "<group>"; };
 		8BA3B6DE23562730005D6278 /* FileSystemMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileSystemMock.swift; sourceTree = "<group>"; };
+		8BADDD0E23E79392006D2204 /* petstore.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = petstore.yaml; sourceTree = "<group>"; };
 		8BD0851923453A1F006D33DE /* StubURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubURL.swift; sourceTree = "<group>"; };
 		8BD0851C23453DAE006D33DE /* Mother.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mother.swift; sourceTree = "<group>"; };
 		8BD085222345E9BD006D33DE /* APIClientSendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientSendTests.swift; sourceTree = "<group>"; };
@@ -377,7 +377,7 @@
 		8B8B19BD23426AEF009D195A /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
-				8B8B19CC23426B83009D195A /* petstore.yaml */,
+				8BADDD0E23E79392006D2204 /* petstore.yaml */,
 				8B30B8672348FC1A00E4D852 /* api */,
 			);
 			path = Fixtures;
@@ -610,7 +610,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1110;
-				LastUpgradeCheck = 1110;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "47 Degrees";
 				TargetAttributes = {
 					8B6B3636234CE1F800D3DE25 = {
@@ -949,6 +949,7 @@
 		8BDE68DE233233CE009342AD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				DEFINES_MODULE = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fortysevendeg;
 				PRODUCT_MODULE_NAME = BowOpenAPI;
@@ -959,6 +960,7 @@
 		8BDE68DF233233CE009342AD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				DEFINES_MODULE = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fortysevendeg;
 				PRODUCT_MODULE_NAME = BowOpenAPI;

--- a/BowOpenAPI.xcodeproj/project.pbxproj
+++ b/BowOpenAPI.xcodeproj/project.pbxproj
@@ -297,7 +297,8 @@
 				8B30B8692348FC1A00E4D852 /* APIConfigTesting.swift */,
 				8B30B86A2348FC1A00E4D852 /* StubURL.swift */,
 			);
-			path = XCTest;
+			name = XCTest;
+			path = Tests/XCTest;
 			sourceTree = "<group>";
 		};
 		8B30B86D2348FC1A00E4D852 /* Sources */ = {
@@ -311,7 +312,8 @@
 				8B30B86F2348FC1A00E4D852 /* APIs */,
 				8B30B8732348FC1A00E4D852 /* Models */,
 			);
-			path = Sources;
+			name = Sources;
+			path = Tests/Sources;
 			sourceTree = "<group>";
 		};
 		8B30B86F2348FC1A00E4D852 /* APIs */ = {

--- a/BowOpenAPI/Console.swift
+++ b/BowOpenAPI/Console.swift
@@ -4,7 +4,7 @@ import Foundation
 
 enum Console {
     static func help() -> Never {
-        print("\(SCRIPT_NAME) --name <name> --schema <schema json|yaml> --output <output path>")
+        print("\(SCRIPT_NAME) --name <name> --schema <scheme json|yaml> --output <output path>")
         print("""
 
                     name: name for the output module.

--- a/BowOpenAPI/main.swift
+++ b/BowOpenAPI/main.swift
@@ -3,7 +3,7 @@
 import Foundation
 import OpenApiGenerator
 
-let prodEnv = Environment(logPath: "/tmp/bow-openapi.log",
+let prodEnv = Environment(log: URL(fileURLWithPath: "/tmp/bow-openapi.log"),
                           fileSystem: MacFileSystem(),
                           generator: SwaggerClientGenerator())
 
@@ -11,7 +11,7 @@ func main() {
     guard let arguments = CommandLine.input else { Console.help() }
     guard FileManager.default.fileExists(atPath: arguments.schema) else { Console.exit(failure: "received invalid schema path") }
     
-    APIClient.bow(moduleName: arguments.name, scheme: arguments.schema, output: arguments.output)
+    APIClient.bow(moduleName: arguments.name, scheme: URL(fileURLWithPath: arguments.schema), output: URL(fileURLWithPath: arguments.output))
              .provide(prodEnv)
              .unsafeRunSyncEither()
              .mapLeft { apiError in "could not generate api client for schema '\(arguments.schema)'\ninformation: \(apiError)" }

--- a/OpenApiGenerator/APIClient.swift
+++ b/OpenApiGenerator/APIClient.swift
@@ -5,34 +5,36 @@ import Bow
 import BowEffects
 
 public enum APIClient {
-    public static func bow(moduleName: String, scheme: String, output: String) -> EnvIO<Environment, APIClientError, String> {
+    public static func bow(moduleName: String, scheme: URL, output: URL) -> EnvIO<Environment, APIClientError, String> {
         EnvIO { env in
-            let template = IO<APIClientError, String>.var()
+            let template = IO<APIClientError, URL>.var()
             return binding(
                 template <- getTemplatePath(),
-                         |<-bow(moduleName: moduleName, scheme: scheme, output: output, templatePath: template.get).provide(env),
+                         |<-bow(moduleName: moduleName, scheme: scheme, output: output, template: template.get).provide(env),
             yield: "RENDER SUCCEEDED")^
         }
     }
     
-    public static func bow(moduleName: String, scheme: String, output: String, templatePath: String) -> EnvIO<Environment, APIClientError, String> {
+    public static func bow(moduleName: String, scheme: URL, output root: URL, template: URL) -> EnvIO<Environment, APIClientError, String> {
         EnvIO { env in
-            let outputPath = OutputPath(sources: "\(output)/Sources", tests: "\(output)/XCTest")
+            let project = root.appendingPathComponent(moduleName)
+            let output = OutputURL(sources: project.appendingPathComponent("Sources"),
+                                   tests: project.appendingPathComponent("XCTest"))
             
             return binding(
-                |<-createStructure(outputPath: outputPath).provide(env.fileSystem),
+                |<-createStructure(output: output).provide(env.fileSystem),
                 |<-env.generator.generate(moduleName: moduleName,
-                                          schemePath: scheme,
-                                          outputPath: outputPath,
-                                          templatePath: templatePath,
-                                          logPath: env.logPath).provide(env.fileSystem),
-                |<-createSwiftPackage(moduleName: moduleName, outputPath: output, templatePath: templatePath).provide(env.fileSystem),
+                                          scheme: scheme,
+                                          output: output,
+                                          template: template,
+                                          log: env.log).provide(env.fileSystem),
+                |<-createSwiftPackage(moduleName: moduleName, output: project, template: template).provide(env.fileSystem),
             yield: "RENDER SUCCEEDED")^
         }
     }
     
     // MARK: attributes
-    private static func getTemplatePath() -> IO<APIClientError, String> {
+    private static func getTemplatePath() -> IO<APIClientError, URL> {
         let libPath = "/usr/local/lib"
         let templateSource1 = Bundle(path: "bow/openapi/templates").toOption()
         let templateSource2 = Bundle(path: "\(libPath)/bow/openapi/templates").toOption()
@@ -42,41 +44,37 @@ public enum APIClient {
             return IO.raiseError(APIClientError(operation: "getTemplatePath()", error: GeneratorError.templateNotFound))^
         }
         
-        return IO.pure(template)^
+        return IO.pure(URL(fileURLWithPath: template))^
     }
     
     // MARK: steps
-    internal static func createStructure(outputPath: OutputPath) -> EnvIO<FileSystem, APIClientError, ()> {
+    internal static func createStructure(output: OutputURL) -> EnvIO<FileSystem, APIClientError, ()> {
         EnvIO { fileSystem in
-            let parentPath = outputPath.sources.parentPath
-            
-            return fileSystem.removeDirectory(parentPath).handleError({ _ in })^
-                             .followedBy(fileSystem.createDirectory(atPath: parentPath))^
-                             .followedBy(fileSystem.createDirectory(atPath: outputPath.sources))^
-                             .followedBy(fileSystem.createDirectory(atPath: outputPath.tests))^
-                             .mapLeft { _ in APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.structure) }
+            fileSystem.removeDirectory(output.sources.path.parentPath).handleError({ _ in })^
+                      .followedBy(fileSystem.createDirectory(at: output.sources, withIntermediates: true))^
+                      .followedBy(fileSystem.createDirectory(at: output.tests, withIntermediates: true))^
+                      .mapLeft { _ in APIClientError(operation: "createStructure(output:)", error: GeneratorError.structure) }
         }
     }
     
-    internal static func createSwiftPackage(moduleName: String, outputPath: String, templatePath: String) -> EnvIO<FileSystem, APIClientError, ()> {
+    internal static func createSwiftPackage(moduleName: String, output: URL, template: URL) -> EnvIO<FileSystem, APIClientError, ()> {
         EnvIO { fileSystem in
-            fileSystem.copy(item: "Package.swift", from: templatePath, to: outputPath)^
-        }.followedBy(package(moduleName: moduleName, outputPath: outputPath))^
-        .mapError(FileSystemError.toAPIClientError)
+            fileSystem.copy(item: "Package.swift", from: template.path, to: output.path)^
+        }.followedBy(package(moduleName: moduleName, output: output))^
+         .mapError(FileSystemError.toAPIClientError)
     }
     
-    internal static func package(moduleName: String, outputPath: String) -> EnvIO<FileSystem, FileSystemError, ()> {
+    internal static func package(moduleName: String, output: URL) -> EnvIO<FileSystem, FileSystemError, ()> {
         EnvIO { fileSystem in
             let content = IO<FileSystemError, String>.var()
             let fixedContent = IO<FileSystemError, String>.var()
-            let path = outputPath + "/Package.swift"
+            let package = output.appendingPathComponent("/Package.swift")
             
             return binding(
-                content <- fileSystem.readFile(atPath: path),
+                     content <- fileSystem.readFile(atPath: package.path),
                 fixedContent <- IO.pure(content.get.replacingOccurrences(of: "{{ moduleName }}", with: moduleName)),
-                |<-fileSystem.write(content: fixedContent.get, toFile: path),
-                yield: ()
-            )^
+                             |<-fileSystem.write(content: fixedContent.get, toFile: package.path),
+            yield: ())^
         }
     }
 }

--- a/OpenApiGenerator/Algebra/ClientGenerator.swift
+++ b/OpenApiGenerator/Algebra/ClientGenerator.swift
@@ -4,11 +4,11 @@ import Foundation
 import Bow
 import BowEffects
 
-public struct OutputPath {
-    let sources: String
-    let tests: String
+public struct OutputURL {
+    let sources: URL
+    let tests: URL
 }
 
 public protocol ClientGenerator {
-    func generate(moduleName: String, schemePath: String, outputPath: OutputPath, templatePath: String, logPath: String) -> EnvIO<FileSystem, APIClientError, ()>
+    func generate(moduleName: String, scheme: URL, output: OutputURL, template: URL, log: URL) -> EnvIO<FileSystem, APIClientError, ()>
 }

--- a/OpenApiGenerator/Algebra/FileSystem.swift
+++ b/OpenApiGenerator/Algebra/FileSystem.swift
@@ -5,7 +5,7 @@ import Bow
 import BowEffects
 
 public protocol FileSystem {
-    func createDirectory(atPath: String) -> IO<FileSystemError, ()>
+    func createDirectory(at folder: URL, withIntermediates: Bool) -> IO<FileSystemError, ()>
     func copy(itemPath: String, toPath: String) -> IO<FileSystemError, ()>
     func remove(itemPath: String) -> IO<FileSystemError, ()>
     func items(atPath path: String) -> IO<FileSystemError, [String]>

--- a/OpenApiGenerator/Environment.swift
+++ b/OpenApiGenerator/Environment.swift
@@ -3,12 +3,12 @@
 import Foundation
 
 public struct Environment {
-    let logPath: String
+    let log: URL
     let fileSystem: FileSystem
     let generator: ClientGenerator
     
-    public init(logPath: String, fileSystem: FileSystem, generator: ClientGenerator) {
-        self.logPath = logPath
+    public init(log: URL, fileSystem: FileSystem, generator: ClientGenerator) {
+        self.log = log
         self.fileSystem = fileSystem
         self.generator = generator
     }

--- a/OpenApiGenerator/MacFileSystem.swift
+++ b/OpenApiGenerator/MacFileSystem.swift
@@ -8,13 +8,14 @@ public class MacFileSystem: FileSystem {
     
     public init() { }
     
-    public func createDirectory(atPath path: String) -> IO<FileSystemError, ()> {
-        FileManager.default.createDirectoryIO(atPath: path, withIntermediateDirectories: false)
-            .mapLeft { _ in .create(item: path) }
+    public func createDirectory(at folder: URL, withIntermediates: Bool = false) -> IO<FileSystemError, ()> {
+        FileManager.default.createDirectoryIO(atPath: folder.path, withIntermediateDirectories: withIntermediates)
+                           .mapLeft { _ in .create(item: folder.path) }
     }
     
     public func copy(itemPath atPath: String, toPath: String) -> IO<FileSystemError, ()> {
-        FileManager.default.copyItemIO(atPath: atPath, toPath: toPath)
+        print("File: \(atPath)\nTo:\(toPath)")
+        return FileManager.default.copyItemIO(atPath: atPath, toPath: toPath)
             .mapLeft { _ in .copy(from: atPath, to: toPath) }
     }
     

--- a/OpenApiGenerator/MacFileSystem.swift
+++ b/OpenApiGenerator/MacFileSystem.swift
@@ -5,7 +5,6 @@ import Bow
 import BowEffects
 
 public class MacFileSystem: FileSystem {
-    
     public init() { }
     
     public func createDirectory(at folder: URL, withIntermediates: Bool = false) -> IO<FileSystemError, ()> {
@@ -13,39 +12,37 @@ public class MacFileSystem: FileSystem {
                            .mapLeft { _ in .create(item: folder.path) }
     }
     
-    public func copy(itemPath atPath: String, toPath: String) -> IO<FileSystemError, ()> {
-        print("File: \(atPath)\nTo:\(toPath)")
-        return FileManager.default.copyItemIO(atPath: atPath, toPath: toPath)
-            .mapLeft { _ in .copy(from: atPath, to: toPath) }
+    public func copy(item: URL, to output: URL) -> IO<FileSystemError, ()> {
+        FileManager.default.copyItemIO(at: item, to: output)
+                           .mapLeft { _ in .copy(from: item.path, to: output.path) }
     }
     
-    public func remove(itemPath: String) -> IO<FileSystemError, ()> {
-        FileManager.default.removeItemIO(atPath: itemPath)
-            .mapLeft { _ in .remove(item: itemPath) }
+    public func remove(item: URL) -> IO<FileSystemError, ()> {
+        FileManager.default.removeItemIO(at: item)
+                           .mapLeft { _ in .remove(item: item.path) }
     }
     
-    public func items(atPath path: String) -> IO<FileSystemError, [String]> {
-        FileManager.default.contentsOfDirectoryIO(atPath: path)
-                           .mapLeft { _ in .get(from: path) }
-                           .map { files in files.map({ file in "\(path)/\(file)"}) }^
+    public func items(at folder: URL) -> IO<FileSystemError, [URL]> {
+        FileManager.default.contentsOfDirectoryIO(at: folder, includingPropertiesForKeys: nil)
+                           .mapLeft { _ in .get(from: folder.path) }^
     }
     
-    public func readFile(atPath path: String) -> IO<FileSystemError, String> {
+    public func readFile(at file: URL) -> IO<FileSystemError, String> {
         IO.invoke {
             do {
-                return try String(contentsOfFile: path)
+                return try String(contentsOfFile: file.path)
             } catch {
-                throw FileSystemError.read(file: path)
+                throw FileSystemError.read(file: file.path)
             }
         }
     }
     
-    public func write(content: String, toFile path: String) -> IO<FileSystemError, ()> {
+    public func write(content: String, toFile file: URL) -> IO<FileSystemError, ()> {
         IO.invoke {
             do {
-                try content.write(toFile: path, atomically: true, encoding: .utf8)
+                try content.write(to: file, atomically: true, encoding: .utf8)
             } catch {
-                throw FileSystemError.write(file: path)
+                throw FileSystemError.write(file: file.path)
             }
         }
     }

--- a/OpenApiGenerator/Utils/String+Format.swift
+++ b/OpenApiGenerator/Utils/String+Format.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public typealias SubstringType = (ouput: String, range: NSRange)
+public typealias SubstringType = (output: String, range: NSRange)
 
 public extension String {
     
@@ -12,21 +12,20 @@ public extension String {
               let match = regex.firstMatch(in: self, options: [], range: range) else { return nil }
 
         let output = NSString(string: self).substring(with: match.range) as String
-
         return (output, match.range)
     }
 
     func clean(_ ocurrences: String...) -> String {
-        return ocurrences.reduce(self) { (output, ocurrence) in
+        ocurrences.reduce(self) { (output, ocurrence) in
             output.replacingOccurrences(of: ocurrence, with: "")
         }
     }
 
     var trimmingWhitespaces: String {
-        return trimmingCharacters(in: .whitespaces)
+        trimmingCharacters(in: .whitespaces)
     }
     
     var trimmingNewLines: String {
-        return trimmingCharacters(in: .newlines)
+        trimmingCharacters(in: .newlines)
     }
 }

--- a/Tests/GeneratorAPIClientTests.swift
+++ b/Tests/GeneratorAPIClientTests.swift
@@ -26,7 +26,7 @@ class GeneratorAPIClientTests: XCTestCase {
     
     
     func testCreateSwiftPackage() {
-        try? APIClient.createSwiftPackage(moduleName: moduleName, outputPath: output.path, templatePath: template.path)
+        try? APIClient.createSwiftPackage(moduleName: moduleName, output: output, template: template)
                       .provide(fileSystem)
                       .unsafeRunSync()
         
@@ -34,23 +34,24 @@ class GeneratorAPIClientTests: XCTestCase {
     }
     
     func testCreateStructure() {
-        let outputPath = OutputPath(sources: "\(output.path)/sources-testing", tests: "\(output.path)/tests-testing")
+        let outputPath = OutputURL(sources: URL(fileURLWithPath: "\(output.path)/sources-testing"),
+                                   tests: URL(fileURLWithPath: "\(output.path)/tests-testing"))
         
-        try? APIClient.createStructure(outputPath: outputPath)
+        try? APIClient.createStructure(output: outputPath)
                       .provide(fileSystem)
                       .unsafeRunSync()
         
-        XCTAssertNotNil(output.find(item: outputPath.sources.filename))
-        XCTAssertNotNil(output.find(item: outputPath.tests.filename))
+        XCTAssertNotNil(output.find(item: outputPath.sources.path.filename))
+        XCTAssertNotNil(output.find(item: outputPath.tests.path.filename))
     }
     
     func testBow_CreateDefaultStructure() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
-        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystem, generator: clientGeneratorMock)
+        let environmentMock = Environment(log: output.appendingPathComponent("log.1.txt"), fileSystem: fileSystem, generator: clientGeneratorMock)
         
-        _ = try? APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, templatePath: template.path)
+        let r = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model), output: output, template: template)
                           .provide(environmentMock)
-                          .unsafeRunSync()
+                          .unsafeRunSyncEither()
         
         XCTAssertNotNil(output.find(item: "Sources"))
         XCTAssertNotNil(output.find(item: "XCTest"))
@@ -58,9 +59,9 @@ class GeneratorAPIClientTests: XCTestCase {
     
     func testBow_GeneratorIsInvoked() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
-        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystem, generator: clientGeneratorMock)
+        let environmentMock = Environment(log: output.appendingPathComponent("log.1.txt"), fileSystem: fileSystem, generator: clientGeneratorMock)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, templatePath: template.path)
+        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model), output: output, template: template)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         
@@ -70,9 +71,9 @@ class GeneratorAPIClientTests: XCTestCase {
     
     func testBow_GeneratorFails_ReturnError() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: true)
-        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystem, generator: clientGeneratorMock)
+        let environmentMock = Environment(log: output.appendingPathComponent("log.1.txt"), fileSystem: fileSystem, generator: clientGeneratorMock)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, templatePath: template.path)
+        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model), output: output, template: template)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         
@@ -83,9 +84,9 @@ class GeneratorAPIClientTests: XCTestCase {
     func testBow_GeneratorAndFileSystemSuccess_ReturnSuccess() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
         let fileSystemMock = FileSystemMock(shouldFail: false)
-        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystemMock, generator: clientGeneratorMock)
+        let environmentMock = Environment(log: output.appendingPathComponent("log.1.txt"), fileSystem: fileSystemMock, generator: clientGeneratorMock)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, templatePath: template.path)
+        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model), output: output, template: template)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         
@@ -95,9 +96,9 @@ class GeneratorAPIClientTests: XCTestCase {
     func testBow_FileSystemFails_ReturnError() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
         let fileSystemMock = FileSystemMock(shouldFail: true)
-        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystemMock, generator: clientGeneratorMock)
+        let environmentMock = Environment(log: output.appendingPathComponent("log.1.txt"), fileSystem: fileSystemMock, generator: clientGeneratorMock)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, templatePath: template.path)
+        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model), output: output, template: template)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         

--- a/Tests/GeneratorSwaggerClientTests.swift
+++ b/Tests/GeneratorSwaggerClientTests.swift
@@ -106,7 +106,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, inFile: outputFile).provide(fileSystem).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -133,7 +133,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                         """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, inFile: outputFile).provide(fileSystem).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -159,7 +159,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, inFile: outputFile).provide(fileSystem).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -184,7 +184,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
         try? headerSection.write(to: file1URL, atomically: true, encoding: .utf8)
         try? headerSection.write(to: file2URL, atomically: true, encoding: .utf8)
         try? headerSection.write(to: file3URL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, inFile: outputFile).provide(fileSystem).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -205,7 +205,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? invalidSignature.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.fixSignatureParameters(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.fixSignatureParameters(filesAt: output).provide(fileSystem).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -220,7 +220,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                              """
 
         try? validSignature.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.fixSignatureParameters(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.fixSignatureParameters(filesAt: output).provide(fileSystem).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)

--- a/Tests/GeneratorSwaggerClientTests.swift
+++ b/Tests/GeneratorSwaggerClientTests.swift
@@ -28,7 +28,6 @@ class GeneratorSwaggerClientTests: XCTestCase {
     
     
     // MARK: - Headers operations
-    
     func testRemoveHeaderSection_ReturnFileUpdated() {
         let fileURL = output.appendingPathComponent("TestRemoveHeaderSection_Valid.swift")
         let contentFile = """
@@ -39,7 +38,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                           """
 
         try? contentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(fileSystem).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -57,7 +56,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                                """
 
         try? extraContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(fileSystem).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -69,7 +68,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
         let noContentFile = "/* \(Constants.headerKey) */"
 
         try? noContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(fileSystem).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -86,7 +85,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                                  """
 
         try? invalidContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(fileSystem).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)

--- a/Tests/Mocks/ClientGeneratorMock.swift
+++ b/Tests/Mocks/ClientGeneratorMock.swift
@@ -1,5 +1,6 @@
 //  Copyright © 2019 The Bow Authors.
 
+import Foundation
 import Bow
 import BowEffects
 
@@ -15,7 +16,7 @@ class ClientGeneratorMock: ClientGenerator {
         self.shouldFail = shouldFail
     }
     
-    func generate(moduleName: String, schemePath: String, outputPath: OutputPath, templatePath: String, logPath: String) -> EnvIO<FileSystem, APIClientError, ()> {
+    func generate(moduleName: String, scheme: URL, output: OutputURL, template: URL, log: URL) -> EnvIO<FileSystem, APIClientError, ()> {
         EnvIO { _ in
             self.generateInvoked = true
             let error = APIClientError(operation: "Testing", error: GeneratorError.structure)

--- a/Tests/Mocks/FileSystemMock.swift
+++ b/Tests/Mocks/FileSystemMock.swift
@@ -1,5 +1,6 @@
 //  Copyright © 2019 The Bow Authors.
 
+import Foundation
 import Bow
 import BowEffects
 
@@ -7,7 +8,6 @@ import BowEffects
 
 
 class FileSystemMock: FileSystem {
-    
     private let shouldFail: Bool
     private(set) var createDirectoryInvoked = false
     private(set) var itemsAtPathInvoked = false
@@ -15,54 +15,59 @@ class FileSystemMock: FileSystem {
     private(set) var writeContentInvoked = false
     private(set) var copyItemPathInvoked = false
     private(set) var removeItemPathInvoked = false
+    private(set) var existItemInvoked = false
     
     init(shouldFail: Bool) {
         self.shouldFail = shouldFail
     }
     
     
-    func createDirectory(atPath: String) -> IO<FileSystemError, ()> {
+    func createDirectory(at folder: URL, withIntermediates: Bool) -> IO<FileSystemError, ()> {
         IO.invoke {
             self.createDirectoryInvoked = true
-            if self.shouldFail { throw FileSystemError.create(item: atPath) }
+            if self.shouldFail { throw FileSystemError.create(item: folder.path) }
         }
     }
     
-    func items(atPath path: String) -> IO<FileSystemError, [String]> {
+    func items(at folder: URL) -> IO<FileSystemError, [URL]> {
         IO.invoke {
             self.itemsAtPathInvoked = true
-            if self.shouldFail { throw FileSystemError.get(from: path) }
-            else { return [""] }
+            if self.shouldFail { throw FileSystemError.get(from: folder.path) }
+            else { return [] }
         }
     }
     
-    func readFile(atPath path: String) -> IO<FileSystemError, String> {
+    func readFile(at file: URL) -> IO<FileSystemError, String> {
         IO.invoke {
             self.readFileAtPathInvoked = true
-            if self.shouldFail { throw FileSystemError.read(file: path) }
+            if self.shouldFail { throw FileSystemError.read(file: file.path) }
             else { return "" }
         }
     }
     
-    func write(content: String, toFile path: String) -> IO<FileSystemError, ()> {
+    func write(content: String, toFile file: URL) -> IO<FileSystemError, ()> {
         IO.invoke {
             self.writeContentInvoked = true
-            if self.shouldFail { throw FileSystemError.write(file: path) }
+            if self.shouldFail { throw FileSystemError.write(file: file.path) }
         }
     }
     
-    func copy(itemPath: String, toPath: String) -> IO<FileSystemError, ()> {
+    func copy(item: URL, to output: URL) -> IO<FileSystemError, ()> {
         IO.invoke {
             self.copyItemPathInvoked = true
-            if self.shouldFail { throw FileSystemError.copy(from: itemPath, to: toPath) }
+            if self.shouldFail { throw FileSystemError.copy(from: item.path, to: output.path) }
         }
     }
     
-    func remove(itemPath: String) -> IO<FileSystemError, ()> {
+    func remove(item: URL) -> IO<FileSystemError, ()> {
         IO.invoke {
             self.removeItemPathInvoked = true
-            if self.shouldFail { throw FileSystemError.remove(item: itemPath) }
+            if self.shouldFail { throw FileSystemError.remove(item: item.path) }
         }
     }
     
+    func exist(item: URL) -> Bool {
+        existItemInvoked = true
+        return shouldFail ? true : false
+    }
 }

--- a/Tests/Utils/Snapshotting+OpenAPI.swift
+++ b/Tests/Utils/Snapshotting+OpenAPI.swift
@@ -8,13 +8,13 @@ extension Snapshotting where Value == URL, Format == String {
     
     static func generated(file focus: String, module: String = "", _ file: StaticString = #file) -> Snapshotting<URL, String> {
         func environment(named: String) -> Environment {
-            Environment(logPath: "/tmp/test\(named).log", fileSystem: MacFileSystem(), generator: SwaggerClientGenerator())
+            Environment(log: URL(fileURLWithPath: "/tmp/test\(named).log"), fileSystem: MacFileSystem(), generator: SwaggerClientGenerator())
         }
         
         var strategy = Snapshotting<String, String>.lines.pullback { (url: URL) -> String in
             let testName = "\(file.string.filename.removeExtension)-focusIn\(focus.removeExtension)"
             let directory = URL.temp(subfolder: testName)
-            let either = APIClient.bow(moduleName: module, scheme: url.path, output: directory.path, templatePath: URL.templates.path)
+            let either = APIClient.bow(moduleName: module, scheme: url, output: directory, template: URL.templates)
                                   .provide(environment(named: testName))
                                   .unsafeRunSyncEither()
             


### PR DESCRIPTION
## Description
- Write the output of Bow OpenAPI into defined Swift Package Module.
- Migrate `paths` to `Foundation.URL` - to remove the ambiguity and add type-check.
- Fix bug: do not remove container folder.