### PR TITLE
Don't clean up output directory

### DIFF
--- a/BowOpenAPI/main.swift
+++ b/BowOpenAPI/main.swift
@@ -21,12 +21,11 @@ extension BowOpenAPICommand {
                     """
                     Could not generate API client:
                     • SCHEMA '\(self.schema)'
-                    
                     \(apiError)
                     
                     \(self.verbose ?
-                    "   • LOG \n\n\(prodEnv.logPath.contentOfFile)\n" :
-                    "   • LOG: \(prodEnv.logPath)")
+                    "• LOG \n\n\(prodEnv.logPath.contentOfFile)\n" :
+                    "• LOG: \(prodEnv.logPath)")
                     """
                 },
                 { success in

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ macos: clean structure install
 .PHONY: fixtures
 fixtures:
 		@rm -rf ./Tests/Fixtures/FixturesAPI
-		$(TOOL_NAME) --name FixturesAPI --schema ./Tests/Fixtures/petstore.yaml --output ./Tests/Fixtures/FixturesAPI --verbose
+		$(TOOL_NAME) --name FixturesAPI --schema ./Tests/Fixtures/petstore.yaml --output ./Tests/Fixtures --verbose
 
 .PHONY: xcode
 xcode: macos fixtures

--- a/OpenApiGenerator/APIClient.swift
+++ b/OpenApiGenerator/APIClient.swift
@@ -58,7 +58,7 @@ public enum APIClient {
     internal static func createStructure(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
         EnvIO { env in
             guard !env.fileSystem.exist(item: module.url) else {
-                return .raiseError(APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.structure))^
+                return .raiseError(APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.existOutput(directory: module.url)))^
             }
             
             return env.fileSystem.createDirectory(at: module.url, withIntermediateDirectories: true)^

--- a/OpenApiGenerator/APIClient.swift
+++ b/OpenApiGenerator/APIClient.swift
@@ -61,9 +61,9 @@ public enum APIClient {
                 return .raiseError(APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.structure))^
             }
             
-            return env.fileSystem.createDirectory(atPath: module.url.path, withIntermediateDirectories: true)^
-                .followedBy(env.fileSystem.createDirectory(atPath: module.sources.path))^
-                .followedBy(env.fileSystem.createDirectory(atPath: module.tests.path))^
+            return env.fileSystem.createDirectory(at: module.url, withIntermediateDirectories: true)^
+                .followedBy(env.fileSystem.createDirectory(at: module.sources))^
+                .followedBy(env.fileSystem.createDirectory(at: module.tests))^
                 .mapError { _ in APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.structure) }
         }
     }
@@ -71,7 +71,7 @@ public enum APIClient {
     internal static func createSwiftPackage(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
         func installPackage(module: OpenAPIModule) -> EnvIO<FileSystem, FileSystemError, Void> {
             EnvIO { fileSystem in
-                fileSystem.copy(item: "Package.swift", from: module.templates.path, to: module.url.path)^
+                fileSystem.copy(item: "Package.swift", from: module.templates, to: module.url)^
             }
         }
         
@@ -82,9 +82,9 @@ public enum APIClient {
                 let output = module.url.appendingPathComponent("Package.swift")
                 
                 return binding(
-                         content <- fileSystem.readFile(atPath: output.path),
+                         content <- fileSystem.readFile(at: output),
                     fixedContent <- IO.pure(content.get.replacingOccurrences(of: "{{ moduleName }}", with: module.name)),
-                                 |<-fileSystem.write(content: fixedContent.get, toFile: output.path),
+                                 |<-fileSystem.write(content: fixedContent.get, toFile: output),
                 yield: ())^
             }
         }

--- a/OpenApiGenerator/APIClient.swift
+++ b/OpenApiGenerator/APIClient.swift
@@ -8,80 +8,90 @@ public enum APIClient {
     
     public static func bow(moduleName: String, schema: String, output: String) -> EnvIO<Environment, APIClientError, String> {
         let env = EnvIO<Environment, APIClientError, Environment>.var()
-        let validated = EnvIO<Environment, APIClientError, String>.var()
-        let template = EnvIO<Environment, APIClientError, URL>.var()
-        let schema = schema.expandingTildeInPath
-        let output = output.expandingTildeInPath
+        let templates = EnvIO<Environment, APIClientError, URL>.var()
+        let generated = EnvIO<Environment, APIClientError, String>.var()
         
         return binding(
-                env <- .ask(),
-           validated <- validate(schema: schema),
-            template <- env.get.generator.getTemplates().contramap(\.fileSystem),
-                     |<-bow(moduleName: moduleName, scheme: validated.get, output: output, template: template.get),
+                 env <- .ask(),
+           templates <- env.get.generator.getTemplates(),
+           generated <- bow(moduleName: moduleName, scheme: schema, output: output, templates: templates.get),
+        yield: generated.get)^
+    }
+    
+    public static func bow(moduleName: String, scheme: String, output: String, templates: URL) -> EnvIO<Environment, APIClientError, String> {
+        let outputURL = URL(fileURLWithPath: output.expandingTildeInPath)
+        let schemeURL = URL(fileURLWithPath: scheme.expandingTildeInPath)
+        let module = OpenAPIModule(name: moduleName,
+                                   url: outputURL,
+                                   schema: schemeURL,
+                                   templates: templates)
+        
+        return bow(module: module)
+    }
+    
+    public static func bow(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, String> {
+        let env = EnvIO<Environment, APIClientError, Environment>.var()
+        let validated = EnvIO<Environment, APIClientError, OpenAPIModule>.var()
+        
+        return binding(
+                  env <- .ask(),
+            validated <- validate(module: module),
+                      |<-createStructure(module: validated.get),
+                      |<-env.get.generator.generate(module: validated.get),
+                      |<-createSwiftPackage(module: validated.get),
         yield: "RENDER SUCCEEDED")^
     }
     
-    public static func bow(moduleName: String, scheme: String, output: String, template: URL) -> EnvIO<Environment, APIClientError, String> {
-        EnvIO { env in
-            let outputPath = OutputPath(sources: "\(output)/Sources",
-                                        tests: "\(output)/XCTest")
-            
-            return binding(
-                |<-createStructure(outputPath: outputPath).provide(env.fileSystem),
-                |<-env.generator.generate(moduleName: moduleName,
-                                          schemePath: scheme,
-                                          outputPath: outputPath,
-                                          template: template,
-                                          logPath: env.logPath).provide(env.fileSystem),
-                |<-createSwiftPackage(moduleName: moduleName, outputPath: output, template: template).provide(env.fileSystem),
-            yield: "RENDER SUCCEEDED")^
-        }
-    }
-    
     // MARK: attributes
-    private static func validate(schema: String) -> EnvIO<Environment, APIClientError, String> {
-        EnvIO.invoke { _ in
-            guard FileManager.default.fileExists(atPath: schema) else {
+    private static func validate(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, OpenAPIModule> {
+        EnvIO.invoke { env in
+            guard env.fileSystem.exist(item: module.schema) else {
                 throw APIClientError(operation: "validate(schema:output:)",
                                     error: GeneratorError.invalidParameters)
             }
             
-            return schema
+            return module
         }
     }
     
     // MARK: steps
-    internal static func createStructure(outputPath: OutputPath) -> EnvIO<FileSystem, APIClientError, ()> {
-        EnvIO { fileSystem in
-            let parentPath = outputPath.sources.parentPath
+    internal static func createStructure(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
+        EnvIO { env in
+            guard !env.fileSystem.exist(item: module.url) else {
+                return .raiseError(APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.structure))^
+            }
             
-            return fileSystem.removeDirectory(parentPath).handleError({ _ in })^
-                             .followedBy(fileSystem.createDirectory(atPath: parentPath))^
-                             .followedBy(fileSystem.createDirectory(atPath: outputPath.sources))^
-                             .followedBy(fileSystem.createDirectory(atPath: outputPath.tests))^
-                             .mapError { _ in APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.structure) }
+            return env.fileSystem.createDirectory(atPath: module.url.path, withIntermediateDirectories: true)^
+                .followedBy(env.fileSystem.createDirectory(atPath: module.sources.path))^
+                .followedBy(env.fileSystem.createDirectory(atPath: module.tests.path))^
+                .mapError { _ in APIClientError(operation: "createStructure(atPath:)", error: GeneratorError.structure) }
         }
     }
     
-    internal static func createSwiftPackage(moduleName: String, outputPath: String, template: URL) -> EnvIO<FileSystem, APIClientError, ()> {
-        EnvIO { fileSystem in
-            fileSystem.copy(item: "Package.swift", from: template.path, to: outputPath)^
-        }.followedBy(package(moduleName: moduleName, outputPath: outputPath))^
-        .mapError(FileSystemError.toAPIClientError)
-    }
-    
-    internal static func package(moduleName: String, outputPath: String) -> EnvIO<FileSystem, FileSystemError, ()> {
-        EnvIO { fileSystem in
-            let content = IO<FileSystemError, String>.var()
-            let fixedContent = IO<FileSystemError, String>.var()
-            let path = outputPath + "/Package.swift"
-            
-            return binding(
-                content <- fileSystem.readFile(atPath: path),
-                fixedContent <- IO.pure(content.get.replacingOccurrences(of: "{{ moduleName }}", with: moduleName)),
-                |<-fileSystem.write(content: fixedContent.get, toFile: path),
-                yield: ()
-            )^
+    internal static func createSwiftPackage(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
+        func installPackage(module: OpenAPIModule) -> EnvIO<FileSystem, FileSystemError, Void> {
+            EnvIO { fileSystem in
+                fileSystem.copy(item: "Package.swift", from: module.templates.path, to: module.url.path)^
+            }
         }
+        
+        func updatePackageName(module: OpenAPIModule) -> EnvIO<FileSystem, FileSystemError, Void> {
+            EnvIO { fileSystem in
+                let content = IO<FileSystemError, String>.var()
+                let fixedContent = IO<FileSystemError, String>.var()
+                let output = module.url.appendingPathComponent("Package.swift")
+                
+                return binding(
+                         content <- fileSystem.readFile(atPath: output.path),
+                    fixedContent <- IO.pure(content.get.replacingOccurrences(of: "{{ moduleName }}", with: module.name)),
+                                 |<-fileSystem.write(content: fixedContent.get, toFile: output.path),
+                yield: ())^
+            }
+        }
+        
+        return installPackage(module: module)
+            .followedBy(updatePackageName(module: module))^
+            .mapError(FileSystemError.toAPIClientError)
+            .contramap(\.fileSystem)^
     }
 }

--- a/OpenApiGenerator/Algebra/ClientGenerator.swift
+++ b/OpenApiGenerator/Algebra/ClientGenerator.swift
@@ -4,12 +4,7 @@ import Foundation
 import Bow
 import BowEffects
 
-public struct OutputPath {
-    let sources: String
-    let tests: String
-}
-
 public protocol ClientGenerator {
-    func getTemplates() -> EnvIO<FileSystem, APIClientError, URL>
-    func generate(moduleName: String, schemePath: String, outputPath: OutputPath, template: URL, logPath: String) -> EnvIO<FileSystem, APIClientError, Void>
+    func getTemplates() -> EnvIO<Environment, APIClientError, URL>
+    func generate(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void>
 }

--- a/OpenApiGenerator/Algebra/FileSystem.swift
+++ b/OpenApiGenerator/Algebra/FileSystem.swift
@@ -5,61 +5,62 @@ import Bow
 import BowEffects
 
 public protocol FileSystem {
-    func createDirectory(atPath path: String, withIntermediateDirectories: Bool) -> IO<FileSystemError, ()>
-    func copy(itemPath: String, toPath: String) -> IO<FileSystemError, ()>
-    func remove(itemPath: String) -> IO<FileSystemError, ()>
-    func items(atPath path: String) -> IO<FileSystemError, [String]>
-    func readFile(atPath path: String) -> IO<FileSystemError, String>
-    func write(content: String, toFile path: String) -> IO<FileSystemError, ()>
+    func createDirectory(at: URL, withIntermediateDirectories: Bool) -> IO<FileSystemError, Void>
+    func copy(item: URL, to: URL) -> IO<FileSystemError, Void>
+    func remove(item: URL) -> IO<FileSystemError, Void>
+    func items(at: URL) -> IO<FileSystemError, [URL]>
+    func readFile(at: URL) -> IO<FileSystemError, String>
+    func write(content: String, toFile: URL) -> IO<FileSystemError, Void>
     func exist(item: URL) -> Bool
 }
 
 public extension FileSystem {
-    func createDirectory(atPath path: String) -> IO<FileSystemError, ()> {
-        createDirectory(atPath: path, withIntermediateDirectories: false)
+    func createDirectory(at directory: URL) -> IO<FileSystemError, Void> {
+        createDirectory(at: directory, withIntermediateDirectories: false)
     }
     
-    func copy(item: String, from input: String, to output: String) -> IO<FileSystemError, ()> {
-        copy(itemPath: "\(input)/\(item)", toPath: "\(output)/\(item)")
+    func copy(item: String, from input: URL, to output: URL) -> IO<FileSystemError, Void> {
+        copy(item: input.appendingPathComponent(item), to: output.appendingPathComponent(item))
     }
     
-    func copy(items: [String], from input: String, to output: String) -> IO<FileSystemError, ()> {
-        items.traverse { (itemPath: String) in
-            self.copy(item: itemPath.filename, from: input, to: output)
+    func copy(items: [String], from input: URL, to output: URL) -> IO<FileSystemError, Void> {
+        items.traverse { (item: String) in
+            self.copy(item: item.filename, from: input, to: output)
         }.void()^
     }
     
-    func remove(from folder: String, files: String...) -> IO<FileSystemError, ()> {
-        files.traverse { file in self.remove(itemPath: "\(folder)/\(file)") }.void()^
+    func remove(in directory: URL, files: [String]) -> IO<FileSystemError, Void> {
+        files.traverse { file in self.remove(item: directory.appendingPathComponent(file)) }.void()^
     }
     
-    func removeDirectory(_ output: String) -> IO<FileSystemError, ()> {
-        let outputURL = URL(fileURLWithPath: output, isDirectory: true)
-        return remove(itemPath: outputURL.path)
+    func removeDirectory(_ directory: URL) -> IO<FileSystemError, Void> {
+        let outputURL = URL(fileURLWithPath: directory.path, isDirectory: true)
+        return remove(item: outputURL)
     }
     
-    func removeFiles(_ files: String...) -> IO<FileSystemError, ()> {
-        files.traverse(remove(itemPath:)).void()^
+    func removeFiles(_ files: [URL]) -> IO<FileSystemError, Void> {
+        files.traverse(remove(item:)).void()^
     }
     
-    func moveFile(from origin: String, to destination: String) -> IO<FileSystemError, Void> {
-        copy(itemPath: origin, toPath: destination)
-            .followedBy(removeFiles(origin))^
+    func moveFile(from origin: URL, to destination: URL) -> IO<FileSystemError, Void> {
+        copy(item: origin, to: destination)
+            .followedBy(removeFiles([origin]))^
             .mapError { _ in .move(from: origin, to: destination) }
     }
     
-    func moveFiles(in input: String, to output: String) -> IO<FileSystemError, ()> {
-        let items = IO<FileSystemError, [String]>.var()
+    func moveFiles(in input: URL, to output: URL) -> IO<FileSystemError, Void> {
+        let items = IO<FileSystemError, [URL]>.var()
         
         return binding(
-            items <- self.items(atPath: input),
-                  |<-self.copy(items: items.get, from: input, to: output),
+            items <- self.items(at: input),
+                  |<-self.copy(items: items.get.map(\.path), from: input, to: output),
                   |<-self.removeDirectory(input),
             yield: ()
         )^.mapError { _ in .move(from: input, to: output) }
     }
     
-    func rename(_ newName: String, itemAt: String) -> IO<FileSystemError, ()> {
-        moveFile(from: itemAt, to: "\(itemAt.parentPath)/\(newName)")
+    func rename(with newName: String, item: URL) -> IO<FileSystemError, Void> {
+        let newItem = item.deletingLastPathComponent().appendingPathComponent(newName)
+        return moveFile(from: item, to: newItem)
     }
 }

--- a/OpenApiGenerator/Algebra/FileSystem.swift
+++ b/OpenApiGenerator/Algebra/FileSystem.swift
@@ -5,15 +5,20 @@ import Bow
 import BowEffects
 
 public protocol FileSystem {
-    func createDirectory(atPath: String) -> IO<FileSystemError, ()>
+    func createDirectory(atPath path: String, withIntermediateDirectories: Bool) -> IO<FileSystemError, ()>
     func copy(itemPath: String, toPath: String) -> IO<FileSystemError, ()>
     func remove(itemPath: String) -> IO<FileSystemError, ()>
     func items(atPath path: String) -> IO<FileSystemError, [String]>
     func readFile(atPath path: String) -> IO<FileSystemError, String>
     func write(content: String, toFile path: String) -> IO<FileSystemError, ()>
+    func exist(item: URL) -> Bool
 }
 
 public extension FileSystem {
+    func createDirectory(atPath path: String) -> IO<FileSystemError, ()> {
+        createDirectory(atPath: path, withIntermediateDirectories: false)
+    }
+    
     func copy(item: String, from input: String, to output: String) -> IO<FileSystemError, ()> {
         copy(itemPath: "\(input)/\(item)", toPath: "\(output)/\(item)")
     }

--- a/OpenApiGenerator/Error/FileSystemError.swift
+++ b/OpenApiGenerator/Error/FileSystemError.swift
@@ -3,32 +3,35 @@
 import Foundation
 
 public enum FileSystemError: Error {
-    case create(item: String)
-    case copy(from: String, to: String)
-    case remove(item: String)
-    case move(from: String, to: String)
-    case get(from: String)
-    case read(file: String)
-    case write(file: String)
+    case create(item: URL)
+    case copy(from: URL, to: URL)
+    case remove(item: URL)
+    case move(from: URL, to: URL)
+    case get(from: URL)
+    case read(file: URL)
+    case invalidContent(info: String)
+    case write(file: URL)
 }
 
 extension FileSystemError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .create(let item):
-            return "cannot create item '\(item)'"
+            return "cannot create item '\(item.path)'"
         case .copy(let from, let to):
-            return "cannot copy item at '\(from)' to '\(to)'"
+            return "cannot copy item at '\(from.path)' to '\(to.path)'"
         case .remove(let item):
-            return "cannot remove item at '\(item)'"
+            return "cannot remove item at '\(item.path)'"
         case .move(let from, let to):
-            return "cannot move item from '\(from)' to '\(to)'"
+            return "cannot move item from '\(from.path)' to '\(to.path)'"
         case .get(let from):
-            return "cannot get items from '\(from)'"
+            return "cannot get items from '\(from.path)'"
         case .read(let file):
-            return "cannot read content of file '\(file)'"
+            return "cannot read content of file '\(file.path)'"
+        case .invalidContent(let info):
+            return "invalid content file \(info)"
         case .write(let file):
-            return "cannot write in file '\(file)'"
+            return "cannot write in file '\(file.path)'"
         }
     }
 }

--- a/OpenApiGenerator/Error/GeneratorError.swift
+++ b/OpenApiGenerator/Error/GeneratorError.swift
@@ -7,6 +7,7 @@ public enum GeneratorError: Error {
     case invalidParameters
     case templateNotFound
     case structure
+    case existOutput(directory: URL)
     case generator
 }
 
@@ -19,6 +20,8 @@ extension GeneratorError: CustomStringConvertible {
             return "templates for generating Bow client have not been found"
         case .structure:
             return "could not create project structure"
+        case .existOutput(let directory):
+            return "output directory '\(directory.path)' already exists"
         case .generator:
             return "command 'swagger-codegen' failed"
         }

--- a/OpenApiGenerator/MacFileSystem.swift
+++ b/OpenApiGenerator/MacFileSystem.swift
@@ -11,43 +11,43 @@ public class MacFileSystem: FileSystem {
         self.fileManager = fileManager
     }
     
-    public func createDirectory(atPath path: String, withIntermediateDirectories: Bool) -> IO<FileSystemError, ()> {
-        fileManager.createDirectoryIO(atPath: path, withIntermediateDirectories: withIntermediateDirectories)
-            .mapError { _ in .create(item: path) }
+    public func createDirectory(at directory: URL, withIntermediateDirectories: Bool) -> IO<FileSystemError, Void> {
+        fileManager.createDirectoryIO(atPath: directory.path, withIntermediateDirectories: withIntermediateDirectories)
+            .mapError { _ in .create(item: directory) }
     }
     
-    public func copy(itemPath atPath: String, toPath: String) -> IO<FileSystemError, ()> {
-        fileManager.copyItemIO(atPath: atPath, toPath: toPath)
-            .mapError { _ in .copy(from: atPath, to: toPath) }
+    public func copy(item: URL, to: URL) -> IO<FileSystemError, Void> {
+        fileManager.copyItemIO(atPath: item.path, toPath: to.path)
+            .mapError { _ in .copy(from: item, to: to) }
     }
     
-    public func remove(itemPath: String) -> IO<FileSystemError, ()> {
-        fileManager.removeItemIO(atPath: itemPath)
-            .mapError { _ in .remove(item: itemPath) }
+    public func remove(item: URL) -> IO<FileSystemError, Void> {
+        fileManager.removeItemIO(atPath: item.path)
+            .mapError { _ in .remove(item: item) }
     }
     
-    public func items(atPath path: String) -> IO<FileSystemError, [String]> {
-        fileManager.contentsOfDirectoryIO(atPath: path)
-            .mapError { _ in .get(from: path) }
-            .map { files in files.map({ file in "\(path)/\(file)"}) }^
+    public func items(at: URL) -> IO<FileSystemError, [URL]> {
+        fileManager.contentsOfDirectoryIO(atPath: at.path)
+            .mapError { _ in .get(from: at) }
+            .map { files in files.map({ file in at.appendingPathComponent(file) }) }^
     }
     
-    public func readFile(atPath path: String) -> IO<FileSystemError, String> {
+    public func readFile(at: URL) -> IO<FileSystemError, String> {
         IO.invoke {
             do {
-                return try String(contentsOfFile: path)
+                return try String(contentsOfFile: at.path)
             } catch {
-                throw FileSystemError.read(file: path)
+                throw FileSystemError.read(file: at)
             }
         }
     }
     
-    public func write(content: String, toFile path: String) -> IO<FileSystemError, ()> {
+    public func write(content: String, toFile item: URL) -> IO<FileSystemError, Void> {
         IO.invoke {
             do {
-                try content.write(toFile: path, atomically: true, encoding: .utf8)
+                try content.write(toFile: item.path, atomically: true, encoding: .utf8)
             } catch {
-                throw FileSystemError.write(file: path)
+                throw FileSystemError.write(file: item)
             }
         }
     }

--- a/OpenApiGenerator/MacFileSystem.swift
+++ b/OpenApiGenerator/MacFileSystem.swift
@@ -5,28 +5,31 @@ import Bow
 import BowEffects
 
 public class MacFileSystem: FileSystem {
+    let fileManager: FileManager
     
-    public init() { }
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
     
-    public func createDirectory(atPath path: String) -> IO<FileSystemError, ()> {
-        FileManager.default.createDirectoryIO(atPath: path, withIntermediateDirectories: false)
+    public func createDirectory(atPath path: String, withIntermediateDirectories: Bool) -> IO<FileSystemError, ()> {
+        fileManager.createDirectoryIO(atPath: path, withIntermediateDirectories: withIntermediateDirectories)
             .mapError { _ in .create(item: path) }
     }
     
     public func copy(itemPath atPath: String, toPath: String) -> IO<FileSystemError, ()> {
-        FileManager.default.copyItemIO(atPath: atPath, toPath: toPath)
+        fileManager.copyItemIO(atPath: atPath, toPath: toPath)
             .mapError { _ in .copy(from: atPath, to: toPath) }
     }
     
     public func remove(itemPath: String) -> IO<FileSystemError, ()> {
-        FileManager.default.removeItemIO(atPath: itemPath)
+        fileManager.removeItemIO(atPath: itemPath)
             .mapError { _ in .remove(item: itemPath) }
     }
     
     public func items(atPath path: String) -> IO<FileSystemError, [String]> {
-        FileManager.default.contentsOfDirectoryIO(atPath: path)
-                           .mapError { _ in .get(from: path) }
-                           .map { files in files.map({ file in "\(path)/\(file)"}) }^
+        fileManager.contentsOfDirectoryIO(atPath: path)
+            .mapError { _ in .get(from: path) }
+            .map { files in files.map({ file in "\(path)/\(file)"}) }^
     }
     
     public func readFile(atPath path: String) -> IO<FileSystemError, String> {
@@ -47,5 +50,9 @@ public class MacFileSystem: FileSystem {
                 throw FileSystemError.write(file: path)
             }
         }
+    }
+    
+    public func exist(item: URL) -> Bool {
+        fileManager.fileExists(atPath: item.path)
     }
 }

--- a/OpenApiGenerator/Models/OpenAPIModule.swift
+++ b/OpenApiGenerator/Models/OpenAPIModule.swift
@@ -7,24 +7,17 @@ public struct OpenAPIModule {
     let url: URL
     let schema: URL
     let templates: URL
-    let sources: URL
-    let tests: URL
+    var sources: URL
+    var tests: URL
     
     public init(name: String, url: URL, schema: URL, templates: URL) {
-        self.init(name: name,
-                  url: url,
-                  schema: schema,
-                  templates: templates,
-                  sources: url.appendingPathComponent("Sources"),
-                  tests: url.appendingPathComponent("XCTest"))
-    }
-    
-    public init(name: String, url: URL, schema: URL, templates: URL, sources: URL, tests: URL) {
+        let output = url.appendingPathComponent(name)
+        
         self.name = name
-        self.url = url.appendingPathComponent(name)
+        self.url = output
         self.schema = schema
         self.templates = templates
-        self.sources = sources
-        self.tests = tests
+        self.sources = output.appendingPathComponent("Sources")
+        self.tests = output.appendingPathComponent("XCTest")
     }
 }

--- a/OpenApiGenerator/Models/OpenAPIModule.swift
+++ b/OpenApiGenerator/Models/OpenAPIModule.swift
@@ -1,0 +1,30 @@
+//  Copyright © 2020 The Bow Authors.
+
+import Foundation
+
+public struct OpenAPIModule {
+    let name: String
+    let url: URL
+    let schema: URL
+    let templates: URL
+    let sources: URL
+    let tests: URL
+    
+    public init(name: String, url: URL, schema: URL, templates: URL) {
+        self.init(name: name,
+                  url: url,
+                  schema: schema,
+                  templates: templates,
+                  sources: url.appendingPathComponent("Sources"),
+                  tests: url.appendingPathComponent("XCTest"))
+    }
+    
+    public init(name: String, url: URL, schema: URL, templates: URL, sources: URL, tests: URL) {
+        self.name = name
+        self.url = url.appendingPathComponent(name)
+        self.schema = schema
+        self.templates = templates
+        self.sources = sources
+        self.tests = tests
+    }
+}

--- a/OpenApiGenerator/SwaggerClientGenerator.swift
+++ b/OpenApiGenerator/SwaggerClientGenerator.swift
@@ -75,7 +75,7 @@ public class SwaggerClientGenerator: ClientGenerator {
         
         return binding(
             env <- .ask(),
-                |<-env.get.fileSystem.copy(items: files, from: module.templates, to: module.url).toAPIClientEnv(),
+                |<-env.get.fileSystem.copy(items: files, from: module.templates, to: module.tests).toAPIClientEnv(),
                 |<-files.traverse(fixTextFilename),
         yield: ())^
     }
@@ -85,7 +85,7 @@ public class SwaggerClientGenerator: ClientGenerator {
         EnvIO { env in
             let content = IO<FileSystemError, String>.var()
             let fixedContent = IO<FileSystemError, String>.var()
-            let file = module.url.appendingPathComponent(filename)
+            let file = module.tests.appendingPathComponent(filename)
             
             return binding(
                     content <- env.fileSystem.readFile(at: file),

--- a/OpenApiGenerator/SwaggerClientGenerator.swift
+++ b/OpenApiGenerator/SwaggerClientGenerator.swift
@@ -6,16 +6,17 @@ import BowEffects
 import Swiftline
 
 public class SwaggerClientGenerator: ClientGenerator {
-    public init() { }
     
+    public init() { }
     
     public func generate(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
         binding(
               |<-self.swaggerGenerator(module: module),
               |<-self.reorganizeFiles(module: module),
-              |<-self.fixSignatureParameters(filesAt: "\(module.sources.path)/APIs"),
-              |<-self.renderHelpersForHeaders(filesAt: "\(module.sources.path)/APIs", inFile: "\(module.sources.path)/APIs.swift"),
-              |<-self.removeHeadersDefinition(filesAt: "\(module.sources.path)/APIs"),
+              |<-self.fixSignatureParameters(filesAt: module.sources.appendingPathComponent("APIs")),
+              |<-self.renderHelpersForHeaders(filesAt: module.sources.appendingPathComponent("APIs"),
+                                              intoFile: module.sources.appendingPathComponent("APIs.swift")),
+              |<-self.removeHeadersDefinition(filesAt: module.sources.appendingPathComponent("APIs")),
         yield: ())^
     }
     
@@ -30,7 +31,8 @@ public class SwaggerClientGenerator: ClientGenerator {
             return URL(fileURLWithPath: template)
         }
     }
-    
+
+    // MARK: - internal methods <generator>
     internal func swaggerGenerator(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
         EnvIO.invoke { env in
             #if os(Linux)
@@ -46,118 +48,151 @@ public class SwaggerClientGenerator: ClientGenerator {
         }
     }
     
+    // MARK: reorganize files
+    internal func reorganizeFiles(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
+        let env = EnvIO<Environment, APIClientError, Environment>.var()
+        
+        let invalidFiles = ["Cartfile", "AlamofireImplementations.swift", "Models.swift", "git_push.sh", "SwaggerClient.podspec", "SwaggerClient", ".swagger-codegen", ".swagger-codegen-ignore", "JSONEncodableEncoding.swift", "JSONEncodingHelper.swift"]
+        
+        let swaggerFiles = module.sources
+            .appendingPathComponent("SwaggerClient")
+            .appendingPathComponent("Classes")
+            .appendingPathComponent("Swaggers")
+        
+        return binding(
+            env <- .ask(),
+            |<-env.get.fileSystem.moveFiles(in: swaggerFiles, to: module.sources).toAPIClientEnv(),
+            |<-env.get.fileSystem.remove(in: module.sources, files: invalidFiles).toAPIClientEnv(),
+            |<-env.get.fileSystem.rename(with: "APIConfiguration.swift", item: module.sources.appendingPathComponent("APIHelper.swift")).toAPIClientEnv(),
+            |<-self.copyTestFiles(module: module),
+        yield: ())^
+    }
     
+    internal func copyTestFiles(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
+        let files = ["API+XCTest.swift", "API+Error.swift", "APIConfigTesting.swift", "StubURL.swift"]
+        let fixTextFilename = module |> fixTestFile
+        let env = EnvIO<Environment, APIClientError, Environment>.var()
+        
+        return binding(
+            env <- .ask(),
+                |<-env.get.fileSystem.copy(items: files, from: module.templates, to: module.url).toAPIClientEnv(),
+                |<-files.traverse(fixTextFilename),
+        yield: ())^
+    }
     
-    
-    
-    internal func reorganizeFiles(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, ()> {
+    // MARK: update files content
+    internal func fixTestFile(module: OpenAPIModule, filename: String) -> EnvIO<Environment, APIClientError, Void> {
         EnvIO { env in
-            binding(
-                |<-env.fileSystem.moveFiles(in: "\(module.sources.path)/SwaggerClient/Classes/Swaggers", to: module.sources.path),
-                |<-env.fileSystem.remove(from: module.sources.path, files: "Cartfile", "AlamofireImplementations.swift", "Models.swift", "git_push.sh", "SwaggerClient.podspec", "SwaggerClient", ".swagger-codegen", ".swagger-codegen-ignore", "JSONEncodableEncoding.swift", "JSONEncodingHelper.swift"),
-                |<-env.fileSystem.rename("APIConfiguration.swift", itemAt: "\(module.sources.path)/APIHelper.swift"),
-                |<-self.copyTestFiles(moduleName: module.name, template: module.templates, outputPath: module.tests.path).provide(env),
-            yield: ())^
+            let content = IO<FileSystemError, String>.var()
+            let fixedContent = IO<FileSystemError, String>.var()
+            let file = module.url.appendingPathComponent(filename)
+            
+            return binding(
+                    content <- env.fileSystem.readFile(at: file),
+               fixedContent <- IO.pure(content.get.replacingOccurrences(of: "{{ moduleName }}", with: module.name)),
+                            |<-env.fileSystem.write(content: fixedContent.get, toFile: file),
+            yield: ())
         }.mapError(FileSystemError.toAPIClientError)
     }
     
-    internal func fixSignatureParameters(filesAt path: String) -> EnvIO<Environment, APIClientError, ()> {
-        func fixSignatureParameters(toFiles files: [String]) -> EnvIO<FileSystem, FileSystemError, ()> {
-            files.traverse(fixSignatureParameters(atFile:)).void()^
-        }
+    internal func fixSignatureParameters(filesAt directory: URL) -> EnvIO<Environment, APIClientError, Void> {
+        let env = EnvIO<Environment, APIClientError, Environment>.var()
+        let items = EnvIO<Environment, APIClientError, [URL]>.var()
         
-        func fixSignatureParameters(atFile path: String) -> EnvIO<FileSystem, FileSystemError, ()> {
-            EnvIO { fileSystem in
-                let content = IO<FileSystemError, String>.var()
-                let fixedContent = IO<FileSystemError, String>.var()
-                
-                return binding(
-                     content <- fileSystem.readFile(atPath: path),
-                fixedContent <- IO.pure(content.get.replacingOccurrences(of: "(, ", with: "(")
-                                                   .replacingOccurrences(of: "(,", with: "(")),
-                             |<-fileSystem.write(content: fixedContent.get, toFile: path),
-                yield: ())
-            }
-        }
-        
-        return EnvIO { env in
-            let items = IO<FileSystemError, [String]>.var()
-            
-            return binding(
-                items <- env.fileSystem.items(atPath: path),
-                |<-fixSignatureParameters(toFiles: items.get).provide(env.fileSystem),
-            yield: ())^.mapError(FileSystemError.toAPIClientError)
-        }
+        return binding(
+              env <- .ask(),
+            items <- env.get.fileSystem.items(at: directory).toAPIClientEnv(),
+                  |<-self.fixSignatureParameters(toFiles: items.get),
+        yield: ())^
     }
     
+    internal func fixSignatureParameters(toFiles files: [URL]) -> EnvIO<Environment, APIClientError, Void> {
+        files.traverse(fixSignatureParameters(atFile:)).void()^
+    }
+    
+    internal func fixSignatureParameters(atFile item: URL) -> EnvIO<Environment, APIClientError, Void> {
+        EnvIO { env in
+            let content = IO<FileSystemError, String>.var()
+            let fixedContent = IO<FileSystemError, String>.var()
+            
+            return binding(
+                content <- env.fileSystem.readFile(at: item),
+            fixedContent <- IO.pure(content.get.replacingOccurrences(of: "(, ", with: "(")
+                                               .replacingOccurrences(of: "(,", with: "(")),
+                         |<-env.fileSystem.write(content: fixedContent.get, toFile: item),
+            yield: ())
+        }.mapError(FileSystemError.toAPIClientError)
+    }
+    
+    // MARK: render files
     private var regexHeaders: String { "(?s)(/\\* API.CONFIG.HEADERS.*\n).*(\\*/)" }
     
-    internal func renderHelpersForHeaders(filesAt path: String, inFile output: String) -> EnvIO<Environment, APIClientError, ()> {
+    internal func renderHelpersForHeaders(filesAt directory: URL, intoFile output: URL) -> EnvIO<Environment, APIClientError, Void> {
         typealias HeaderValue = (type: String, header: String)
-        
+
         func headerInformation(content: String) -> IO<FileSystemError, [String: HeaderValue]> {
             guard let plainHeaders = content.substring(pattern: regexHeaders)?.ouput.components(separatedBy: "\n") else {
-                return IO.raiseError(FileSystemError.read(file: "::headerInformation"))^
+                return IO.raiseError(FileSystemError.invalidContent(info: "::headerInformation"))^
             }
-            
+
             let headers = plainHeaders.compactMap { string -> [String: HeaderValue]? in
                 let components = string.components(separatedBy: ":")
                 guard components.count == 3 else { return nil }
                 return [components[0].trimmingWhitespaces: (components[1].trimmingWhitespaces, components[2].trimmingWhitespaces)]
             }
-            
+
             return IO.pure(headers.combineAll())^
         }
-        
+
         func renderHelpers(headers: [String: HeaderValue]) -> String {
             guard headers.count > 0 else { return "" }
-            
+
             let methods = headers.map { (arg) -> String in
                 let (key, (type, header)) = arg
                 return """
-                       
+
                            public func appendingHeader(\(key): \(type)) -> API.Config {
                                self.copy(headers: self.headers.combine(["\(header)": \(key)]))
                            }
                        """
             }
-            
+
             return """
                    extension API.Config {
                    \(methods.reduce("", +))
                    }
                    """
         }
-        
+
         return EnvIO { env in
-            let items = IO<FileSystemError, [String]>.var()
+            let items = IO<FileSystemError, [URL]>.var()
             let contents = IO<FileSystemError, [String]>.var()
             let headers = IO<FileSystemError, [[String: HeaderValue]]>.var()
             let flattenHeaders = IO<FileSystemError, [String: HeaderValue]>.var()
             let helpers = IO<FileSystemError, String>.var()
-            let file = IO<FileSystemError, String>.var()
-            
+            let fileContent = IO<FileSystemError, String>.var()
+
             return binding(
-                items <- env.fileSystem.items(atPath: path),
-                      contents <- items.get.traverse(env.fileSystem.readFile(atPath:)),
-                       headers <- contents.get.traverse(headerInformation),
-                flattenHeaders <- IO.pure(headers.get.combineAll()),
-                       helpers <- IO.pure(renderHelpers(headers: flattenHeaders.get)),
-                          file <- env.fileSystem.readFile(atPath: output),
-                               |<-env.fileSystem.write(content: "\(file.get)\n\n\(helpers.get)", toFile: output),
+                        items <- env.fileSystem.items(at: directory),
+                     contents <- items.get.traverse(env.fileSystem.readFile(at:)),
+                      headers <- contents.get.traverse(headerInformation),
+               flattenHeaders <- IO.pure(headers.get.combineAll()),
+                      helpers <- IO.pure(renderHelpers(headers: flattenHeaders.get)),
+                  fileContent <- env.fileSystem.readFile(at: output),
+                              |<-env.fileSystem.write(content: "\(fileContent.get)\n\n\(helpers.get)", toFile: output),
             yield: ())^.mapError(FileSystemError.toAPIClientError)
         }
     }
     
-    internal func removeHeadersDefinition(filesAt path: String) -> EnvIO<Environment, APIClientError, ()> {
-        func removeHeadersDefinition(atFile file: String) -> EnvIO<FileSystem, FileSystemError, ()> {
+    internal func removeHeadersDefinition(filesAt directory: URL) -> EnvIO<Environment, APIClientError, Void> {
+        func removeHeadersDefinition(atFile file: URL) -> EnvIO<FileSystem, FileSystemError, Void> {
             EnvIO { fileSystem in
                 let content = IO<FileSystemError, String>.var()
                 let headers = IO<FileSystemError, String>.var()
                 let contentWithoutHeaders = IO<FileSystemError, String>.var()
-                
+
                 return binding(
-                                  content <- fileSystem.readFile(atPath: file),
+                                  content <- fileSystem.readFile(at: file),
                                   headers <- IO.pure(content.get.substring(pattern: self.regexHeaders)?.ouput ?? ""),
                     contentWithoutHeaders <- IO.pure(content.get.clean(headers.get)),
                                           |<-fileSystem.write(content: contentWithoutHeaders.get, toFile: file),
@@ -165,38 +200,14 @@ public class SwaggerClientGenerator: ClientGenerator {
             }
         }
         
-        return EnvIO { env in
-            let items = IO<FileSystemError, [String]>.var()
-            
-            return binding(
-                items <- env.fileSystem.items(atPath: path),
-                |<-items.get.traverse(removeHeadersDefinition(atFile:))^.provide(env.fileSystem),
-            yield: ())^.mapError(FileSystemError.toAPIClientError)
-        }
-    }
-    
-    internal func copyTestFiles(moduleName: String, template: URL, outputPath: String) -> EnvIO<Environment, FileSystemError, Void> {
-        let files = ["API+XCTest.swift", "API+Error.swift", "APIConfigTesting.swift", "StubURL.swift"]
+        let env = EnvIO<Environment, FileSystemError, Environment>.var()
+        let items = EnvIO<Environment, FileSystemError, [URL]>.var()
         
-        return EnvIO { env in
-            binding(
-                |<-env.fileSystem.copy(items: files, from: template.path, to: outputPath),
-                |<-files.traverse { file in self.fixTestFile(moduleName: moduleName, fileName: file, outputPath: outputPath).provide(env) },
-                yield: ())
-        }^
-    }
-    
-    internal func fixTestFile(moduleName: String, fileName: String, outputPath: String) -> EnvIO<Environment, FileSystemError, Void> {
-        let content = IO<FileSystemError, String>.var()
-        let fixedContent = IO<FileSystemError, String>.var()
-        let path = outputPath + "/" + fileName
-        
-        return EnvIO { env in
-            binding(
-                content <- env.fileSystem.readFile(atPath: path),
-                fixedContent <- IO.pure(content.get.replacingOccurrences(of: "{{ moduleName }}", with: moduleName)),
-                |<-env.fileSystem.write(content: fixedContent.get, toFile: path),
-                yield: ())
-        }
+        return binding(
+              env <- .ask(),
+            items <- env.get.fileSystem.items(at: directory).env(),
+                  |<-items.get.traverse(removeHeadersDefinition(atFile:))^.contramap(\.fileSystem),
+        yield: ())^
+            .mapError(FileSystemError.toAPIClientError)
     }
 }

--- a/OpenApiGenerator/SwaggerClientGenerator.swift
+++ b/OpenApiGenerator/SwaggerClientGenerator.swift
@@ -6,20 +6,20 @@ import BowEffects
 import Swiftline
 
 public class SwaggerClientGenerator: ClientGenerator {
-    
     public init() { }
     
-    public func generate(moduleName: String, schemePath: String, outputPath: OutputPath, template: URL, logPath: String) -> EnvIO<FileSystem, APIClientError, ()> {
-        return binding(
-              |<-self.swaggerGenerator(scheme: schemePath, output: outputPath.sources, template: template, logPath: logPath),
-              |<-self.reorganizeFiles(moduleName: moduleName, in: outputPath, fromTemplate: template),
-              |<-self.fixSignatureParameters(filesAt: "\(outputPath.sources)/APIs"),
-              |<-self.renderHelpersForHeaders(filesAt: "\(outputPath.sources)/APIs", inFile: "\(outputPath.sources)/APIs.swift"),
-              |<-self.removeHeadersDefinition(filesAt: "\(outputPath.sources)/APIs"),
+    
+    public func generate(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
+        binding(
+              |<-self.swaggerGenerator(module: module),
+              |<-self.reorganizeFiles(module: module),
+              |<-self.fixSignatureParameters(filesAt: "\(module.sources.path)/APIs"),
+              |<-self.renderHelpersForHeaders(filesAt: "\(module.sources.path)/APIs", inFile: "\(module.sources.path)/APIs.swift"),
+              |<-self.removeHeadersDefinition(filesAt: "\(module.sources.path)/APIs"),
         yield: ())^
     }
     
-    public func getTemplates() -> EnvIO<FileSystem, APIClientError, URL> {
+    public func getTemplates() -> EnvIO<Environment, APIClientError, URL> {
         EnvIO.invoke { _ in
             let libPath = "/usr/local/lib"
             guard let bundle = Bundle(path: "\(libPath)/bowopenapi/Templates"),
@@ -31,37 +31,37 @@ public class SwaggerClientGenerator: ClientGenerator {
         }
     }
     
-    internal func swaggerGenerator(scheme: String, output: String, template: URL, logPath: String) -> EnvIO<FileSystem, APIClientError, ()> {
-        func runSwagger() -> IO<APIClientError, ()> {
-            IO.invoke {
-                #if os(Linux)
-                let result = run("java", args: ["-jar", "/usr/local/bin/swagger-codegen-cli.jar"] + ["generate", "--lang", "swift4", "--input-spec", "\(scheme)", "--output", "\(output)", "--template-dir", "\(template.path)"])
-                #else
-                let result = run("/usr/local/bin/swagger-codegen", args: ["generate", "--lang", "swift4", "--input-spec", "\(scheme)", "--output", "\(output)", "--template-dir", "\(template.path)"]) { settings in
-                    settings.execution = .log(file: logPath)
-                }
-                #endif
-                
-                let hasError = result.exitStatus != 0 || result.stdout.contains("ERROR")
-                if hasError { throw APIClientError(operation: "swaggerGenerator(scheme:output:template:logPath:)", error: GeneratorError.generator) }
+    internal func swaggerGenerator(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
+        EnvIO.invoke { env in
+            #if os(Linux)
+            let result = run("java", args: ["-jar", "/usr/local/bin/swagger-codegen-cli.jar"] + ["generate", "--lang", "swift4", "--input-spec", "\(module.scheme.path)", "--output", "\(module.sources.path)", "--template-dir", "\(module.templates.path)"])
+            #else
+            let result = run("/usr/local/bin/swagger-codegen", args: ["generate", "--lang", "swift4", "--input-spec", "\(module.schema.path)", "--output", "\(module.sources.path)", "--template-dir", "\(module.templates.path)"]) { settings in
+                settings.execution = .log(file: env.logPath)
             }
+            #endif
+            
+            let hasError = result.exitStatus != 0 || result.stdout.contains("ERROR")
+            if hasError { throw APIClientError(operation: "swaggerGenerator(scheme:output:template:logPath:)", error: GeneratorError.generator) }
         }
-        
-        return EnvIO { _ in runSwagger() }
     }
     
-    internal func reorganizeFiles(moduleName: String, in outputPath: OutputPath, fromTemplate template: URL) -> EnvIO<FileSystem, APIClientError, ()> {
-        EnvIO { fileSystem in
+    
+    
+    
+    
+    internal func reorganizeFiles(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, ()> {
+        EnvIO { env in
             binding(
-                |<-fileSystem.moveFiles(in: "\(outputPath.sources)/SwaggerClient/Classes/Swaggers", to: outputPath.sources),
-                |<-fileSystem.remove(from: outputPath.sources, files: "Cartfile", "AlamofireImplementations.swift", "Models.swift", "git_push.sh", "SwaggerClient.podspec", "SwaggerClient", ".swagger-codegen", ".swagger-codegen-ignore", "JSONEncodableEncoding.swift", "JSONEncodingHelper.swift"),
-                |<-fileSystem.rename("APIConfiguration.swift", itemAt: "\(outputPath.sources)/APIHelper.swift"),
-                |<-self.copyTestFiles(moduleName: moduleName, template: template, outputPath: outputPath.tests).provide(fileSystem),
-            yield: ())^.mapError(FileSystemError.toAPIClientError)
-        }
+                |<-env.fileSystem.moveFiles(in: "\(module.sources.path)/SwaggerClient/Classes/Swaggers", to: module.sources.path),
+                |<-env.fileSystem.remove(from: module.sources.path, files: "Cartfile", "AlamofireImplementations.swift", "Models.swift", "git_push.sh", "SwaggerClient.podspec", "SwaggerClient", ".swagger-codegen", ".swagger-codegen-ignore", "JSONEncodableEncoding.swift", "JSONEncodingHelper.swift"),
+                |<-env.fileSystem.rename("APIConfiguration.swift", itemAt: "\(module.sources.path)/APIHelper.swift"),
+                |<-self.copyTestFiles(moduleName: module.name, template: module.templates, outputPath: module.tests.path).provide(env),
+            yield: ())^
+        }.mapError(FileSystemError.toAPIClientError)
     }
     
-    internal func fixSignatureParameters(filesAt path: String) -> EnvIO<FileSystem, APIClientError, ()> {
+    internal func fixSignatureParameters(filesAt path: String) -> EnvIO<Environment, APIClientError, ()> {
         func fixSignatureParameters(toFiles files: [String]) -> EnvIO<FileSystem, FileSystemError, ()> {
             files.traverse(fixSignatureParameters(atFile:)).void()^
         }
@@ -80,19 +80,19 @@ public class SwaggerClientGenerator: ClientGenerator {
             }
         }
         
-        return EnvIO { fileSystem in
+        return EnvIO { env in
             let items = IO<FileSystemError, [String]>.var()
             
             return binding(
-                items <- fileSystem.items(atPath: path),
-                      |<-fixSignatureParameters(toFiles: items.get).provide(fileSystem),
+                items <- env.fileSystem.items(atPath: path),
+                |<-fixSignatureParameters(toFiles: items.get).provide(env.fileSystem),
             yield: ())^.mapError(FileSystemError.toAPIClientError)
         }
     }
     
     private var regexHeaders: String { "(?s)(/\\* API.CONFIG.HEADERS.*\n).*(\\*/)" }
     
-    internal func renderHelpersForHeaders(filesAt path: String, inFile output: String) -> EnvIO<FileSystem, APIClientError, ()> {
+    internal func renderHelpersForHeaders(filesAt path: String, inFile output: String) -> EnvIO<Environment, APIClientError, ()> {
         typealias HeaderValue = (type: String, header: String)
         
         func headerInformation(content: String) -> IO<FileSystemError, [String: HeaderValue]> {
@@ -129,7 +129,7 @@ public class SwaggerClientGenerator: ClientGenerator {
                    """
         }
         
-        return EnvIO { fileSystem in
+        return EnvIO { env in
             let items = IO<FileSystemError, [String]>.var()
             let contents = IO<FileSystemError, [String]>.var()
             let headers = IO<FileSystemError, [[String: HeaderValue]]>.var()
@@ -138,18 +138,18 @@ public class SwaggerClientGenerator: ClientGenerator {
             let file = IO<FileSystemError, String>.var()
             
             return binding(
-                         items <- fileSystem.items(atPath: path),
-                      contents <- items.get.traverse(fileSystem.readFile(atPath:)),
+                items <- env.fileSystem.items(atPath: path),
+                      contents <- items.get.traverse(env.fileSystem.readFile(atPath:)),
                        headers <- contents.get.traverse(headerInformation),
                 flattenHeaders <- IO.pure(headers.get.combineAll()),
                        helpers <- IO.pure(renderHelpers(headers: flattenHeaders.get)),
-                          file <- fileSystem.readFile(atPath: output),
-                               |<-fileSystem.write(content: "\(file.get)\n\n\(helpers.get)", toFile: output),
+                          file <- env.fileSystem.readFile(atPath: output),
+                               |<-env.fileSystem.write(content: "\(file.get)\n\n\(helpers.get)", toFile: output),
             yield: ())^.mapError(FileSystemError.toAPIClientError)
         }
     }
     
-    internal func removeHeadersDefinition(filesAt path: String) -> EnvIO<FileSystem, APIClientError, ()> {
+    internal func removeHeadersDefinition(filesAt path: String) -> EnvIO<Environment, APIClientError, ()> {
         func removeHeadersDefinition(atFile file: String) -> EnvIO<FileSystem, FileSystemError, ()> {
             EnvIO { fileSystem in
                 let content = IO<FileSystemError, String>.var()
@@ -165,37 +165,37 @@ public class SwaggerClientGenerator: ClientGenerator {
             }
         }
         
-        return EnvIO { fileSystem in
+        return EnvIO { env in
             let items = IO<FileSystemError, [String]>.var()
             
             return binding(
-                items <- fileSystem.items(atPath: path),
-                      |<-items.get.traverse(removeHeadersDefinition(atFile:))^.provide(fileSystem),
+                items <- env.fileSystem.items(atPath: path),
+                |<-items.get.traverse(removeHeadersDefinition(atFile:))^.provide(env.fileSystem),
             yield: ())^.mapError(FileSystemError.toAPIClientError)
         }
     }
     
-    internal func copyTestFiles(moduleName: String, template: URL, outputPath: String) -> EnvIO<FileSystem, FileSystemError, ()> {
+    internal func copyTestFiles(moduleName: String, template: URL, outputPath: String) -> EnvIO<Environment, FileSystemError, Void> {
         let files = ["API+XCTest.swift", "API+Error.swift", "APIConfigTesting.swift", "StubURL.swift"]
         
-        return EnvIO { fileSystem in
+        return EnvIO { env in
             binding(
-                |<-fileSystem.copy(items: files, from: template.path, to: outputPath),
-                |<-files.traverse { file in self.fixTestFile(moduleName: moduleName, fileName: file, outputPath: outputPath).provide(fileSystem) },
+                |<-env.fileSystem.copy(items: files, from: template.path, to: outputPath),
+                |<-files.traverse { file in self.fixTestFile(moduleName: moduleName, fileName: file, outputPath: outputPath).provide(env) },
                 yield: ())
         }^
     }
     
-    internal func fixTestFile(moduleName: String, fileName: String, outputPath: String) -> EnvIO<FileSystem, FileSystemError, ()> {
+    internal func fixTestFile(moduleName: String, fileName: String, outputPath: String) -> EnvIO<Environment, FileSystemError, Void> {
         let content = IO<FileSystemError, String>.var()
         let fixedContent = IO<FileSystemError, String>.var()
         let path = outputPath + "/" + fileName
         
-        return EnvIO { fileSystem in
+        return EnvIO { env in
             binding(
-                content <- fileSystem.readFile(atPath: path),
+                content <- env.fileSystem.readFile(atPath: path),
                 fixedContent <- IO.pure(content.get.replacingOccurrences(of: "{{ moduleName }}", with: moduleName)),
-                |<-fileSystem.write(content: fixedContent.get, toFile: path),
+                |<-env.fileSystem.write(content: fixedContent.get, toFile: path),
                 yield: ())
         }
     }

--- a/OpenApiGenerator/SwaggerClientGenerator.swift
+++ b/OpenApiGenerator/SwaggerClientGenerator.swift
@@ -36,7 +36,7 @@ public class SwaggerClientGenerator: ClientGenerator {
     internal func swaggerGenerator(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
         EnvIO.invoke { env in
             #if os(Linux)
-            let result = run("java", args: ["-jar", "/usr/local/bin/swagger-codegen-cli.jar"] + ["generate", "--lang", "swift4", "--input-spec", "\(module.scheme.path)", "--output", "\(module.sources.path)", "--template-dir", "\(module.templates.path)"])
+            let result = run("java", args: ["-jar", "/usr/local/bin/swagger-codegen-cli.jar"] + ["generate", "--lang", "swift4", "--input-spec", "\(module.schema.path)", "--output", "\(module.sources.path)", "--template-dir", "\(module.templates.path)"])
             #else
             let result = run("/usr/local/bin/swagger-codegen", args: ["generate", "--lang", "swift4", "--input-spec", "\(module.schema.path)", "--output", "\(module.sources.path)", "--template-dir", "\(module.templates.path)"]) { settings in
                 settings.execution = .log(file: env.logPath)

--- a/OpenApiGenerator/Utils/IO+APIClient.swift
+++ b/OpenApiGenerator/Utils/IO+APIClient.swift
@@ -1,0 +1,11 @@
+//  Copyright © 2020 The Bow Authors.
+
+import Foundation
+import Bow
+import BowEffects
+
+extension IO where E == FileSystemError {
+    func toAPIClientEnv<D>() -> EnvIO<D, APIClientError, A> {
+        mapError(FileSystemError.toAPIClientError).env()
+    }
+}

--- a/Tests/GeneratorAPIClientTests.swift
+++ b/Tests/GeneratorAPIClientTests.swift
@@ -44,10 +44,8 @@ class GeneratorAPIClientTests: XCTestCase {
         let module = OpenAPIModule(name: moduleName,
                                    url: output,
                                    schema: URL(fileURLWithPath: ""),
-                                   templates: templates,
-                                   sources: URL(fileURLWithPath: "\(output.path)/sources-testing"),
-                                   tests: URL(fileURLWithPath: "\(output.path)/tests-testing"))
-        
+                                   templates: templates)
+                                   
         try? APIClient.createStructure(module: module)
                       .provide(env(fileSystem: fileSystem))
                       .unsafeRunSync()

--- a/Tests/GeneratorAPIClientTests.swift
+++ b/Tests/GeneratorAPIClientTests.swift
@@ -7,11 +7,14 @@ import BowEffects
 
 
 class GeneratorAPIClientTests: XCTestCase {
-    
     private let moduleName = "TestModule"
     private let fileSystem = MacFileSystem()
     private let output = URL.temp(subfolder: String(#file).filename.removeExtension)
-    private let template = URL.templates
+    private let templates = URL.templates
+    
+    private func env(fileSystem: FileSystem) -> Environment {
+        .init(logPath: "", fileSystem: fileSystem, generator: ClientGeneratorMock(shouldFail: false))
+    }
     
     override func setUp() {
         super.setUp()
@@ -25,29 +28,43 @@ class GeneratorAPIClientTests: XCTestCase {
     
     
     func testCreateSwiftPackage() {
-        try? APIClient.createSwiftPackage(moduleName: moduleName, outputPath: output.path, template: template)
-                      .provide(fileSystem)
+        let module = OpenAPIModule(name: output.path.filename,
+                                   url: output.deletingLastPathComponent(),
+                                   schema: URL(fileURLWithPath: ""),
+                                   templates: templates)
+        
+        try? APIClient.createSwiftPackage(module: module)
+                      .provide(env(fileSystem: fileSystem))
                       .unsafeRunSync()
         
         XCTAssertNotNil(output.find(item: "Package.swift"))
     }
     
     func testCreateStructure() {
-        let outputPath = OutputPath(sources: "\(output.path)/sources-testing", tests: "\(output.path)/tests-testing")
+        let module = OpenAPIModule(name: moduleName,
+                                   url: output,
+                                   schema: URL(fileURLWithPath: ""),
+                                   templates: templates,
+                                   sources: URL(fileURLWithPath: "\(output.path)/sources-testing"),
+                                   tests: URL(fileURLWithPath: "\(output.path)/tests-testing"))
         
-        try? APIClient.createStructure(outputPath: outputPath)
-                      .provide(fileSystem)
+        try? APIClient.createStructure(module: module)
+                      .provide(env(fileSystem: fileSystem))
                       .unsafeRunSync()
         
-        XCTAssertNotNil(output.find(item: outputPath.sources.filename))
-        XCTAssertNotNil(output.find(item: outputPath.tests.filename))
+        XCTAssertNotNil(output.find(item: module.sources.path.filename))
+        XCTAssertNotNil(output.find(item: module.tests.path.filename))
     }
     
     func testBow_CreateDefaultStructure() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
         let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystem, generator: clientGeneratorMock)
+        let module = OpenAPIModule(name: moduleName,
+                                   url: output,
+                                   schema: URL.schemas.file(.model),
+                                   templates: templates)
         
-        _ = try? APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, template: template)
+        _ = try? APIClient.bow(module: module)
                           .provide(environmentMock)
                           .unsafeRunSync()
         
@@ -58,8 +75,12 @@ class GeneratorAPIClientTests: XCTestCase {
     func testBow_GeneratorIsInvoked() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
         let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystem, generator: clientGeneratorMock)
+        let module = OpenAPIModule(name: moduleName,
+                                   url: output,
+                                   schema: URL.schemas.file(.model),
+                                   templates: templates)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, template: template)
+        let either = APIClient.bow(module: module)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         
@@ -70,8 +91,12 @@ class GeneratorAPIClientTests: XCTestCase {
     func testBow_GeneratorFails_ReturnError() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: true)
         let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystem, generator: clientGeneratorMock)
+        let module = OpenAPIModule(name: moduleName,
+                                   url: output,
+                                   schema: URL.schemas.file(.model),
+                                   templates: templates)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, template: template)
+        let either = APIClient.bow(module: module)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         
@@ -81,10 +106,13 @@ class GeneratorAPIClientTests: XCTestCase {
     
     func testBow_GeneratorAndFileSystemSuccess_ReturnSuccess() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
-        let fileSystemMock = FileSystemMock(shouldFail: false)
-        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystemMock, generator: clientGeneratorMock)
+        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: MacFileSystem(), generator: clientGeneratorMock)
+        let module = OpenAPIModule(name: moduleName,
+                                   url: output,
+                                   schema: URL.schemas.file(.model),
+                                   templates: templates)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, template: template)
+        let either = APIClient.bow(module: module)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         
@@ -93,10 +121,13 @@ class GeneratorAPIClientTests: XCTestCase {
     
     func testBow_FileSystemFails_ReturnError() {
         let clientGeneratorMock = ClientGeneratorMock(shouldFail: false)
-        let fileSystemMock = FileSystemMock(shouldFail: true)
-        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: fileSystemMock, generator: clientGeneratorMock)
+        let environmentMock = Environment(logPath: "\(output.path)/log.1.txt", fileSystem: FileSystemMock(shouldFail: true), generator: clientGeneratorMock)
+        let module = OpenAPIModule(name: moduleName,
+                                   url: output,
+                                   schema: URL.schemas.file(.model),
+                                   templates: templates)
         
-        let either = APIClient.bow(moduleName: moduleName, scheme: URL.schemas.file(.model).path, output: output.path, template: template)
+        let either = APIClient.bow(module: module)
                               .provide(environmentMock)
                               .unsafeRunSyncEither()
         

--- a/Tests/GeneratorSwaggerClientTests.swift
+++ b/Tests/GeneratorSwaggerClientTests.swift
@@ -41,7 +41,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                           """
 
         try? contentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -59,7 +59,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                                """
 
         try? extraContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -71,7 +71,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
         let noContentFile = "/* \(Constants.headerKey) */"
 
         try? noContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -88,7 +88,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                                  """
 
         try? invalidContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -109,7 +109,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, intoFile: outputFile).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -136,7 +136,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                         """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, intoFile: outputFile).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -162,7 +162,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, intoFile: outputFile).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -187,7 +187,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
         try? headerSection.write(to: file1URL, atomically: true, encoding: .utf8)
         try? headerSection.write(to: file2URL, atomically: true, encoding: .utf8)
         try? headerSection.write(to: file3URL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output, intoFile: outputFile).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -208,7 +208,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? invalidSignature.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.fixSignatureParameters(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.fixSignatureParameters(filesAt: output).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -223,7 +223,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                              """
 
         try? validSignature.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.fixSignatureParameters(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
+        let either = sut.fixSignatureParameters(filesAt: output).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)

--- a/Tests/GeneratorSwaggerClientTests.swift
+++ b/Tests/GeneratorSwaggerClientTests.swift
@@ -7,12 +7,15 @@ import BowEffects
 
 
 class GeneratorSwaggerClientTests: XCTestCase {
-    
     private let sut = SwaggerClientGenerator()
     private let fileSystem = MacFileSystem()
     private let output = URL.temp(subfolder: String(#file).filename.removeExtension)
     private lazy var outputFile = output.parent.appendingPathComponent("Test_Output.swift")
     private let template = URL.templates
+    
+    private func env(fileSystem: FileSystem) -> Environment {
+        .init(logPath: "", fileSystem: fileSystem, generator: ClientGeneratorMock(shouldFail: false))
+    }
     
     override func setUp() {
         super.setUp()
@@ -38,7 +41,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                           """
 
         try? contentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -56,7 +59,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                                """
 
         try? extraContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -68,7 +71,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
         let noContentFile = "/* \(Constants.headerKey) */"
 
         try? noContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -85,7 +88,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                                  """
 
         try? invalidContentFile.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.removeHeadersDefinition(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let newContentFile = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -106,7 +109,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -133,7 +136,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                         """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -159,7 +162,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? headerSection.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -184,7 +187,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
         try? headerSection.write(to: file1URL, atomically: true, encoding: .utf8)
         try? headerSection.write(to: file2URL, atomically: true, encoding: .utf8)
         try? headerSection.write(to: file3URL, atomically: true, encoding: .utf8)
-        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.renderHelpersForHeaders(filesAt: output.path, inFile: outputFile.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: outputFile)
         
         XCTAssert(either.isRight)
@@ -205,7 +208,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                        """
 
         try? invalidSignature.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.fixSignatureParameters(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.fixSignatureParameters(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)
@@ -220,7 +223,7 @@ class GeneratorSwaggerClientTests: XCTestCase {
                              """
 
         try? validSignature.write(to: fileURL, atomically: true, encoding: .utf8)
-        let either = sut.fixSignatureParameters(filesAt: output.path).provide(fileSystem).unsafeRunSyncEither()
+        let either = sut.fixSignatureParameters(filesAt: output.path).provide(env(fileSystem: fileSystem)).unsafeRunSyncEither()
         let rendered = try! String(contentsOf: fileURL)
         
         XCTAssert(either.isRight)

--- a/Tests/Mocks/ClientGeneratorMock.swift
+++ b/Tests/Mocks/ClientGeneratorMock.swift
@@ -13,7 +13,7 @@ class ClientGeneratorMock: ClientGenerator {
         self.shouldFail = shouldFail
     }
     
-    func generate(moduleName: String, schemePath: String, outputPath: OutputPath, template: URL, logPath: String) -> EnvIO<FileSystem, APIClientError, ()> {
+    func generate(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, ()> {
         EnvIO { _ in
             self.generateInvoked = true
             let error = APIClientError(operation: "Testing", error: GeneratorError.structure)
@@ -21,7 +21,7 @@ class ClientGeneratorMock: ClientGenerator {
         }
     }
     
-    func getTemplates() -> EnvIO<FileSystem, APIClientError, URL> {
+    func getTemplates() -> EnvIO<Environment, APIClientError, URL> {
         EnvIO.pure(URL.templates)^
     }
 }

--- a/Tests/Mocks/ClientGeneratorMock.swift
+++ b/Tests/Mocks/ClientGeneratorMock.swift
@@ -13,7 +13,7 @@ class ClientGeneratorMock: ClientGenerator {
         self.shouldFail = shouldFail
     }
     
-    func generate(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, ()> {
+    func generate(module: OpenAPIModule) -> EnvIO<Environment, APIClientError, Void> {
         EnvIO { _ in
             self.generateInvoked = true
             let error = APIClientError(operation: "Testing", error: GeneratorError.structure)

--- a/Tests/Mocks/FileSystemMock.swift
+++ b/Tests/Mocks/FileSystemMock.swift
@@ -19,51 +19,49 @@ class FileSystemMock: FileSystem {
     }
     
     
-    func createDirectory(atPath: String, withIntermediateDirectories: Bool) -> IO<FileSystemError, ()> {
+    func createDirectory(at: URL, withIntermediateDirectories: Bool) -> IO<FileSystemError, Void> {
         IO.invoke {
             self.createDirectoryInvoked = true
-            if self.shouldFail { throw FileSystemError.create(item: atPath) }
+            if self.shouldFail { throw FileSystemError.create(item: at) }
         }
     }
     
-    func items(atPath path: String) -> IO<FileSystemError, [String]> {
+    func items(at: URL) -> IO<FileSystemError, [URL]> {
         IO.invoke {
             self.itemsAtPathInvoked = true
-            if self.shouldFail { throw FileSystemError.get(from: path) }
-            else { return [""] }
+            if self.shouldFail { throw FileSystemError.get(from: at) }
+            else { return [URL(fileURLWithPath: "")] }
         }
     }
     
-    func readFile(atPath path: String) -> IO<FileSystemError, String> {
+    func readFile(at: URL) -> IO<FileSystemError, String> {
         IO.invoke {
             self.readFileAtPathInvoked = true
-            if self.shouldFail { throw FileSystemError.read(file: path) }
+            if self.shouldFail { throw FileSystemError.read(file: at) }
             else { return "" }
         }
     }
     
-    func write(content: String, toFile path: String) -> IO<FileSystemError, ()> {
+    func write(content: String, toFile: URL) -> IO<FileSystemError, Void> {
         IO.invoke {
             self.writeContentInvoked = true
-            if self.shouldFail { throw FileSystemError.write(file: path) }
+            if self.shouldFail { throw FileSystemError.write(file: toFile) }
         }
     }
     
-    func copy(itemPath: String, toPath: String) -> IO<FileSystemError, ()> {
+    func copy(item: URL, to: URL) -> IO<FileSystemError, Void> {
         IO.invoke {
             self.copyItemPathInvoked = true
-            if self.shouldFail { throw FileSystemError.copy(from: itemPath, to: toPath) }
+            if self.shouldFail { throw FileSystemError.copy(from: item, to: to) }
         }
     }
     
-    func remove(itemPath: String) -> IO<FileSystemError, ()> {
+    func remove(item: URL) -> IO<FileSystemError, Void> {
         IO.invoke {
             self.removeItemPathInvoked = true
-            if self.shouldFail { throw FileSystemError.remove(item: itemPath) }
+            if self.shouldFail { throw FileSystemError.remove(item: item) }
         }
     }
     
-    func exist(item: URL) -> Bool {
-        true
-    }
+    func exist(item: URL) -> Bool { true }
 }

--- a/Tests/Mocks/FileSystemMock.swift
+++ b/Tests/Mocks/FileSystemMock.swift
@@ -6,7 +6,6 @@ import BowEffects
 import OpenApiGenerator
 
 class FileSystemMock: FileSystem {
-    
     private let shouldFail: Bool
     private(set) var createDirectoryInvoked = false
     private(set) var itemsAtPathInvoked = false
@@ -20,7 +19,7 @@ class FileSystemMock: FileSystem {
     }
     
     
-    func createDirectory(atPath: String) -> IO<FileSystemError, ()> {
+    func createDirectory(atPath: String, withIntermediateDirectories: Bool) -> IO<FileSystemError, ()> {
         IO.invoke {
             self.createDirectoryInvoked = true
             if self.shouldFail { throw FileSystemError.create(item: atPath) }
@@ -64,4 +63,7 @@ class FileSystemMock: FileSystem {
         }
     }
     
+    func exist(item: URL) -> Bool {
+        true
+    }
 }

--- a/Tests/PackageGeneratedTests.swift
+++ b/Tests/PackageGeneratedTests.swift
@@ -6,6 +6,6 @@ import SnapshotTesting
 
 class PackageGeneratedTests: XCTestCase {
     func testBuildProjectWithSwiftPackage() {
-        assertSnapshot(matching: URL.schemas.file(.json), as: .generated(file: "Package.swift", module: "PetStore"))
+        assertSnapshot(matching: URL.schemas.file(.json), as: .generated(file: "Package.swift", moduleName: "PetStore"))
     }
 }

--- a/Tests/Utils/IO+Error.swift
+++ b/Tests/Utils/IO+Error.swift
@@ -1,0 +1,17 @@
+//  Copyright © 2020 The Bow Authors.
+
+import Foundation
+import Bow
+import BowEffects
+
+extension EnvIO where A == Void {
+    func ignoreError<E: Swift.Error, EE: Error>() -> EnvIO<D, EE, Void> where F == IOPartial<E> {
+        handleError { _ in }^.mapError { e in e as! EE }
+    }
+}
+
+extension IO where A == Void {
+    func ignoreError<EE: Error>() -> IO<EE, Void> {
+        handleError { _ in }^.mapError { e in e as! EE }
+    }
+}

--- a/Tests/Utils/Snapshotting+OpenAPI.swift
+++ b/Tests/Utils/Snapshotting+OpenAPI.swift
@@ -18,9 +18,7 @@ extension Snapshotting where Value == URL, Format == String {
             let env = environment(named: testName)
             let directory = URL.temp(subfolder: testName)
             let apiClientIO = APIClient.bow(moduleName: moduleName, scheme: url.path, output: directory.path, templates: URL.templates)
-            let removeDirectoryIO: EnvIO<Environment, APIClientError, Void> = env.fileSystem.removeDirectory(directory)
-                .handleError { _ in }^
-                .mapError { e in e as! APIClientError }^.env()
+            let removeDirectoryIO: EnvIO<Environment, APIClientError, Void> = env.fileSystem.removeDirectory(directory).ignoreError().env()
                 
             let either = removeDirectoryIO.followedBy(apiClientIO)^.provide(env).unsafeRunSyncEither()
             

--- a/Tests/Utils/Snapshotting+OpenAPI.swift
+++ b/Tests/Utils/Snapshotting+OpenAPI.swift
@@ -18,7 +18,7 @@ extension Snapshotting where Value == URL, Format == String {
             let env = environment(named: testName)
             let directory = URL.temp(subfolder: testName)
             let apiClientIO = APIClient.bow(moduleName: moduleName, scheme: url.path, output: directory.path, templates: URL.templates)
-            let removeDirectoryIO: EnvIO<Environment, APIClientError, Void> = env.fileSystem.removeDirectory(directory.path)
+            let removeDirectoryIO: EnvIO<Environment, APIClientError, Void> = env.fileSystem.removeDirectory(directory)
                 .handleError { _ in }^
                 .mapError { e in e as! APIClientError }^.env()
                 

--- a/Tests/Utils/Snapshotting+OpenAPI.swift
+++ b/Tests/Utils/Snapshotting+OpenAPI.swift
@@ -3,21 +3,26 @@
 import Foundation
 import OpenApiGenerator
 import SnapshotTesting
-
+import Bow
+import BowEffects
 
 extension Snapshotting where Value == URL, Format == String {
     
-    static func generated(file focus: String, module: String = "", _ file: StaticString = #file) -> Snapshotting<URL, String> {
+    static func generated(file focus: String, moduleName: String = "", _ file: StaticString = #file) -> Snapshotting<URL, String> {
         func environment(named: String) -> Environment {
             Environment(logPath: "/tmp/test\(named).log", fileSystem: MacFileSystem(), generator: SwaggerClientGenerator())
         }
         
         var strategy = Snapshotting<String, String>.lines.pullback { (url: URL) -> String in
             let testName = "\(file.string.filename.removeExtension)-focusIn\(focus.removeExtension)"
+            let env = environment(named: testName)
             let directory = URL.temp(subfolder: testName)
-            let either = APIClient.bow(moduleName: module, scheme: url.path, output: directory.path, template: URL.templates)
-                                  .provide(environment(named: testName))
-                                  .unsafeRunSyncEither()
+            let apiClientIO = APIClient.bow(moduleName: moduleName, scheme: url.path, output: directory.path, templates: URL.templates)
+            let removeDirectoryIO: EnvIO<Environment, APIClientError, Void> = env.fileSystem.removeDirectory(directory.path)
+                .handleError { _ in }^
+                .mapError { e in e as! APIClientError }^.env()
+                
+            let either = removeDirectoryIO.followedBy(apiClientIO)^.provide(env).unsafeRunSyncEither()
             
             guard either.isRight else {
                 return  """


### PR DESCRIPTION
## Description
If the project name in the selected output already exists, the current version removes the project folder (and its content). This PR fixes it and launch an error instead to clean up the directory.