### PR TITLE
Shell auto-completion

### DIFF
--- a/BowOpenAPI/BowOpenAPICommand.swift
+++ b/BowOpenAPI/BowOpenAPICommand.swift
@@ -15,6 +15,6 @@ struct BowOpenAPICommand: ParsableCommand {
     @Option(help: ArgumentHelp("Path where the Swift package containing the network client will be generated. ex. `/home`.", valueName: "output path"))
     var output: String
     
-    @ArgumentParser.Flag (help: "Run in verbose mode")
-    var verbose: Bool
+    @ArgumentParser.Flag(help: "Run in verbose mode")
+    var verbose: Bool = false
 }

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ install:
 		@install $(BUILD_PATH)/build/release/$(TOOL_NAME) $(PREFIX_BIN)/$(TOOL_NAME)
 		@cp -R ./Templates $(RESOURCES_PATH)
 		@cp ./Tests/Fixtures/petstore.yaml $(RESOURCES_PATH)
+		$(MAKE) bash
+		$(MAKE) zsh
 
 .PHONY: dependencies
 dependencies:
@@ -52,3 +54,17 @@ uninstall:
 .PHONY: clean
 clean: uninstall
 		@rm -rf $(BUILD_PATH)
+
+.PHONY: zsh
+zsh:
+	@mkdir -p ~/.zsh/completion
+	@mkdir -p ~/.oh-my-zsh/completions
+	@$(TOOL_NAME) --generate-completion-script zsh > ~/.oh-my-zsh/completions/_$(TOOL_NAME)
+	@$(TOOL_NAME) --generate-completion-script zsh > ~/.zsh/completion/$(TOOL_NAME).zsh
+	$(shell if [[ ! -f ~/.zshrc ]] || [[ ! `grep "~/.zsh/completion" ~/.zshrc` ]]; then echo -e '\n# Enable Zsh completions\nfpath=(~/.zsh/completion $$fpath)\nautoload -U compinit\ncompinit\n' >> ~/.zshrc; fi)
+
+.PHONY: bash
+bash:
+	@mkdir -p ~/.bash_completions
+	@$(TOOL_NAME) --generate-completion-script bash > ~/.bash_completions/$(TOOL_NAME).bash
+	$(shell if [[ ! -f ~/.bashrc ]] || [[ ! `grep "$(TOOL_NAME).bash" ~/.bashrc` ]]; then echo "source ~/.bash_completions/$(TOOL_NAME).bash" >> ~/.bashrc; fi)

--- a/Package.swift
+++ b/Package.swift
@@ -112,7 +112,7 @@ let package = Package(
 
     dependencies: [
         .package(name: "Bow", url: "https://github.com/bow-swift/bow.git", .exact("0.8.0")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.0.5")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.2.1")),
         .package(url: "https://github.com/bow-swift/Swiftline.git", .exact("0.5.5")),
         .package(name: "SnapshotTesting", url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .exact("1.7.2")),
         .package(url: "https://github.com/bow-swift/SwiftCheck.git", .exact("0.12.1")),


### PR DESCRIPTION
## Details
Yesterday `swift-argument-parser` released version `0.2.1` adding support to [shell-completion](https://github.com/apple/swift-argument-parser/issues/1). Taking advantage of this new feature, I have upgrade code to this version and modify `Makefile` to install completions scripts after each install.

## Limitations
Right now, it is only compatible with `bash` and `zsh`, but they also have in the roadmap integrate [fish](https://github.com/apple/swift-argument-parser/issues/214)